### PR TITLE
Fix rawhide builds due to wrong chroot name

### DIFF
--- a/fedora-copr/build.py
+++ b/fedora-copr/build.py
@@ -211,7 +211,7 @@ class CoprBuilder(object):
                         projectname=self.__projectname,
                         chrootname=chroot,
                         with_opts="snapshot_build",
-                        additional_repos=["https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-snapshot-builder/fedora-$releasever-$basearch"],
+                        additional_repos=["https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-snapshot-builder/" + chroot],
                         additional_packages="llvm-snapshot-builder"
                     )
             build = self.__client.package_proxy.build(


### PR DESCRIPTION
The rawhide chroots are called fedora-rawhide-x86_64 or similar,
not fedora-37-x86_64. As we already know the exact chroot name,
just use it directly rather than rederiving it.