### PR TITLE
Test new method of cleaning and forking in copr

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -31,14 +31,18 @@ jobs:
         with:
           python-version: 3.9
 
-      - uses: actions/checkout@v2
+      - name: "checkout this repo"
+        uses: actions/checkout@v2
 
-      - run: |
+      - name: "install python requirements"
+        run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-        
-      - name: copr build
-        env:
+
+      - name: "prepare variables"
+        # We specify the secrets here and give them an alias for other steps to
+        # repeat the options.
+        env: &secrets
           # You need to have those secrets in your repo.
           # See also: https://copr.fedorainfracloud.org/api/.
           COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
@@ -46,11 +50,38 @@ jobs:
           COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
           COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: vars
         run: |
-          python fedora-copr/build.py \
-            --regenerate-repos \
-            --ownername "@fedora-llvm-team" \
-            --projectname "llvm-snapshots"
+          ownername_today=kkleine
+          ownername_yesterday=kkleine
+          ownername_target=kkleine
+          
+          projectname_today=llvm-snapshots-incubator-`date +%Y%m%d`
+          projectname_yesterday=llvm-snapshots-incubator-`date -d '-1 day' +%Y%m%d`
+          projectname_target=llvm-snapshots
+
+          echo -n "::set-output name=ownername_today::$ownername_today"
+          echo -n "::set-output name=ownername_yesterday::$ownername_yesterday"
+          echo -n "::set-output name=ownername_target::$ownername_target"
+
+          echo -n "::set-output name=projectname_today::$projectname_today"
+          echo -n "::set-output name=projectname_yesterday::$projectname_yesterday"
+          echo -n "::set-output name=projectname_target::$projectname_target"
+
+          echo -n "::set-output name=op_today::$ownername_today/$projectname_today"
+          echo -n "::set-output name=op_yesterday::$ownername_yesterday/$projectname_yesterday"
+          echo -n "::set-output name=op_target::$ownername_target/$projectname_target"
+
+          # check if yesterday's project exists
+          yesterdays_project_exists=`python fedora-copr/build.py \
+            --project-exists \
+            --ownername "$onwername_yesterday" \
+            --projectname $projectname_yesterday`
+          echo -n "::set-output name=yesterdays_project_exists::$yesterdays_project_exists"
+
+      - name: "copr kick-off new builds in ${{ steps.vars.outputs.op_today }}"
+        env: *secrets
+        run: |
           python fedora-copr/build.py \
             --chroots \
                 fedora-35-aarch64 \
@@ -69,7 +100,28 @@ jobs:
                 fedora-rawhide-i386 \
                 fedora-rawhide-s390x \
             --yyyymmdd "$(date +%Y%m%d)" \
-            --ownername "@fedora-llvm-team" \
-            --projectname "llvm-snapshots" \
+            --ownername "${{ steps.vars.outputs.ownername_today }}" \
+            --projectname "${{ steps.vars.outputs.projectname_today }}" \
             --timeout "108000" \
+            --delete-after-days 7 \
             --max-num-builds 70  ${{ github.event.inputs.opts }}
+
+      - name: copr fork project from ${{ steps.vars.outputs.op_yesterday }} to ${{ steps.vars.outputs.op_target }}
+        if: ${{ steps.vars.outputs.yesterdays_project_exists == 'yes' }}
+        env: *secrets
+        run: |
+          python fedora-copr/build.py \
+            --fork-from "${{ steps.vars.outputs.op_yesterday }}" \
+            --ownername "${{ steps.vars.outputs.onwername_target }}" \
+            --projectname "${{ steps.vars.outputs.projectname_target }}"
+
+      - name: copr regenerate ${{ steps.vars.outputs.op_target }}
+        # If yesterday's project didn't exist, we haven't forked and so we don't
+        # need to regenerate the repos.
+        if: ${{ steps.vars.outputs.yesterdays_project_exists == 'yes' }}
+        env: *secrets
+        run: |
+          python fedora-copr/build.py \
+            --regenerate-repos \
+            --ownername "${{ steps.vars.outputs.onwername_target }}" \
+            --projectname "${{ steps.vars.outputs.projectname_target }}"


### PR DESCRIPTION
Rework how we build snapshots

When we build a snapshot we want to build it with the clang that
ships with Fedora. What happened before was that we've build clang with
the latest version of clang that we've built ourselves. This is of
course unfortunate.

This is an approach to have three copr projects:

0. `llvm-snapshots-incubator-<YESTERDAY>` (will be kept for 7 days)
1. `llvm-snapshots-incubator-<TODAY>` (will be kept for 7 days)
2. `llvm-snapshots` (will be overwritten each day with `llvm-snapshots-incubator-<TODAY>`)

The `llvm-snapshots` project is *forked* from the
`llvm-snapshot-incubator-<YESTERDAY>` over and over again every day. This copies
over successful builds from the `llvm-snapshots-incubator-<YESTERDAY>` project.

The advantages are:

 * Every day we build in a fresh project without any packages from previous builds.
 * We can look back 7 days and see projects.
 * We don't have to tell users to change how they get the snapshots.

Downsides:

 * Collecting statistics need to be adjusted.
 * Lot more juggling with projects.

I hope this makes sense and looks right.

NOTICE: For now I'll do this under my ownername (`kkleine` and not under `@fedora-llvm-team`)
