### PR TITLE
llvm-snapshot-builder: Fix yyyymmdd definition

### DIFF
--- a/llvm-snapshot-builder/Makefile
+++ b/llvm-snapshot-builder/Makefile
@@ -35,7 +35,7 @@ source:
 	mkdir -p $(TMP)/SOURCES
 	mkdir -p $(TMP)/$(PACKAGE)
 	cp -a $(FILES) $(TMP)/$(PACKAGE)
-	echo "%{lua: rpm.define('yyyymmdd $(YYYYMMDD_TODAY)')}" >> $(TMP)/$(PACKAGE)/macros.$(PACKAGE)
+	echo "%yyyymmdd $(YYYYMMDD_TODAY)" >> $(TMP)/$(PACKAGE)/macros.$(PACKAGE)
 
 .PHONY: rpm
 rpm: tarball


### PR DESCRIPTION
I don't think defines are allowed in the system macro files, so this was causing an error:

error: /usr/lib/rpm/macros.d/macros.llvm-snapshot-builder: line 209: Macro % has illegal name (%define)