### PR TITLE
Re-enable automatic metadata generation for incubator projects

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -140,7 +140,6 @@ jobs:
             --enable-net on \
             --runtime-repo-dependency "https://download.copr.fedorainfracloud.org/results/%40fedora-llvm-team/llvm-compat-packages/fedora-\$releasever-\$basearch" \
             --multilib on \
-            --disable_createrepo 1 \
             --appstream off \
             --delete-after-days 32 \
             $chroot_opts "${{ env.project_today }}"


### PR DESCRIPTION
We need to be able to to install the llvm-snapshot-builder package from the current COPR project during the SRPM build phase.  This phase does not have access to to the internal repositories, so it needs to be able to install the llvm-snapshot-builder package from the public COPR repositories, which is only possible if we are re-generating the metadata aftereach build.

See https://src.fedoraproject.org/rpms/libomp/c/471201f1e41afcfab9b657a279d460e03792994e