### PR TITLE
Stop building for Fedora 36

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -33,12 +33,7 @@ jobs:
           yesterday=`date -d "${today} -1 day" +%Y%m%d`
 
           packages="python-lit llvm clang lld compiler-rt libomp"
-          chroots="fedora-36-aarch64 \
-                   fedora-36-ppc64le \
-                   fedora-36-x86_64 \
-                   fedora-36-i386 \
-                   fedora-36-s390x \
-                   fedora-37-aarch64 \
+          chroots="fedora-37-aarch64 \
                    fedora-37-ppc64le \
                    fedora-37-x86_64 \
                    fedora-37-i386 \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ yyyymmdd ?= $(today)
 buildroot ?= $(pwd)/buildroot/$(yyyymmdd)
 
 # The default chroot to build for.
-chroot ?= fedora-36-x86_64
+chroot ?= fedora-37-x86_64
 
 # The mock config that will be used as a template for the final mock config.
 # In it we will place the chroot defined above.


### PR DESCRIPTION
Fedora 36 has reached end-of-life on 2023-05-16, so stop providing snapshot builds for it.

Trying to produce snapshots for Fedora 36 currently breaks snapshots entirely, as building i386 for Fedora 36 on COPR is no longer supported.