### PR TITLE
Build for latest fedora versions

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -33,21 +33,7 @@ jobs:
           yesterday=`date -d "${today} -1 day" +%Y%m%d`
 
           packages="python-lit llvm clang lld compiler-rt libomp"
-          chroots="fedora-37-aarch64 \
-                   fedora-37-ppc64le \
-                   fedora-37-x86_64 \
-                   fedora-37-i386 \
-                   fedora-37-s390x \
-                   fedora-38-aarch64 \
-                   fedora-38-ppc64le \
-                   fedora-38-x86_64 \
-                   fedora-38-i386 \
-                   fedora-38-s390x \
-                   fedora-rawhide-aarch64 \
-                   fedora-rawhide-ppc64le \
-                   fedora-rawhide-x86_64 \
-                   fedora-rawhide-i386 \
-                   fedora-rawhide-s390x"
+          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)'`"
 
           username=@fedora-llvm-team
           echo "username=$username" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ yyyymmdd ?= $(today)
 buildroot ?= $(pwd)/buildroot/$(yyyymmdd)
 
 # The default chroot to build for.
-chroot ?= fedora-37-x86_64
+chroot ?= $(shell copr list-chroots | grep -P '^fedora-[0-9]+-x86_64' | sort | head -1)
 
 # The mock config that will be used as a template for the final mock config.
 # In it we will place the chroot defined above.


### PR DESCRIPTION
Automatically decide for which fedora versions to build based on `copr
list-chroots`.
