### PR TITLE
Avoid newlines in chroot variable

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -33,7 +33,7 @@ jobs:
           yesterday=`date -d "${today} -1 day" +%Y%m%d`
 
           packages="python-lit llvm clang lld compiler-rt libomp"
-          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)'`"
+          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)'` | tr '\n' ' '"
 
           username=@fedora-llvm-team
           echo "username=$username" >> $GITHUB_ENV

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -33,7 +33,7 @@ jobs:
           yesterday=`date -d "${today} -1 day" +%Y%m%d`
 
           packages="python-lit llvm clang lld compiler-rt libomp"
-          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)'` | tr '\n' ' '"
+          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)' | tr '\n' ' '`"
 
           username=@fedora-llvm-team
           echo "username=$username" >> $GITHUB_ENV


### PR DESCRIPTION
The current way of exporting into $GITHUB_ENV only works for single-line values. Replace the newlines in the chroot list with spaces.