### PR TITLE
Automate wave through

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -51,14 +51,12 @@ jobs:
         run: |
           source github/functions.sh
 
-          # Check if yesterday's project exists and is waved through
+          # Check if yesterday's project exists and all builds succeeded
           yesterdays_project_exists=`project_exists ${{ env.project_yesterday }}`
           if [[ "$yesterdays_project_exists" == "true" ]]; then
-            url=https://copr.fedorainfracloud.org/coprs/`echo ${{ env.project_yesterday }} | sed -s 's/^@/\/g\//'`
-            curl -sL -o page.html $url 2>&1
-            grep "`head -n1 project-description.md`" page.html \
-              && yesterdays_project_exists="false" \
-              || true
+            if has_not_succeeded_builds ${{env.project_yesterday}}; then
+              yesterdays_project_exists=false
+            fi
           fi
 
           echo "todays_project_exists=`project_exists ${{ env.project_today }}`" >> $GITHUB_ENV

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -29,11 +29,13 @@ jobs:
       - name: "Variables and functions"
         shell: bash -e {0}
         run: |
+          source github/functions.sh
+
           today=`date +%Y%m%d`
           yesterday=`date -d "${today} -1 day" +%Y%m%d`
 
-          packages="python-lit llvm clang lld compiler-rt libomp"
-          chroots="`copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)' | tr '\n' ' '`"
+          packages="`get_packages`"
+          chroots="`get_chroots"
 
           username=@fedora-llvm-team
           echo "username=$username" >> $GITHUB_ENV
@@ -145,7 +147,7 @@ jobs:
             # Start a new batch
             after_build_id=""
             for pkg in ${{ env.packages }}; do
-              if [[ ("${pkg}" == "lld" || "${pkg}" == "libomp") && $chroot =~ -s390x$ ]]; then
+              if is_package_supported_by_chroot "$pkg" "$chroot"; then
                 echo "Skipping lld for s390x architecture in chroot: ${chroot}";
               else
                 copr build-package \

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -44,31 +44,12 @@ jobs:
           echo "project_yesterday=$username/llvm-snapshots-incubator-$yesterday" >> $GITHUB_ENV
           echo "project_target=$username/llvm-snapshots" >> $GITHUB_ENV
 
-          cat <<EOF > ~/functions.sh
-          set -x
-          # set -e
-          # TODO(kwk): Is there a better way to check project existence?
-          # TODO(kwk): Maybe: copr list $username | grep --regexp="^Name: \$project$"
-          function project_exists(){
-            local project=\$1;
-            copr get-chroot \$project/fedora-rawhide-x86_64 > /dev/null 2>&1 \
-            && echo "true" || echo "false";
-          }
-
-          function get_active_build_ids(){
-            local project=\$1;
-            copr list-builds --output-format text-row \$project \
-              | grep --perl-regexp --regexp='(running|waiting|pending|importing|starting)' \
-              | cut -f 1
-          }
-          EOF
-
       - uses: actions/checkout@v3
 
       - name: "Check for Copr projects existence (yesterday, today, target)"
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
 
           # Check if yesterday's project exists and is waved through
           yesterdays_project_exists=`project_exists ${{ env.project_yesterday }}`
@@ -88,7 +69,7 @@ jobs:
         if: ${{ env.todays_project_exists == 'true' }}
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
           build_ids=""
           for build_id in `get_active_build_ids ${{ env.project_today }}`; do
             echo "Canceling build with ID $build_id"
@@ -104,13 +85,13 @@ jobs:
         if: ${{ env.todays_project_exists == 'true' }}
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
           copr delete ${{ env.project_today }}
 
       - name: "Create today's Copr project: ${{ env.project_today }}"
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
 
           chroot_opts=`for c in ${{ env.chroots }}; do echo -n " --chroot $c "; done`
 
@@ -128,7 +109,7 @@ jobs:
       - name: "Create today's packages: ${{ env.packages }}"
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
 
           for pkg in ${{ env.packages }}; do
             copr add-package-scm \
@@ -144,7 +125,7 @@ jobs:
       - name: "Build llvm-snapshot-builder from SRPM into today's project: ${{ env.project_today }}"
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
           make -C llvm-snapshot-builder/ srpm
           copr build \
             "${{ env.project_today }}" \
@@ -153,7 +134,7 @@ jobs:
       - name: "Build packages in chroot batches in this order: ${{ env.packages }}"
         shell: bash -e {0}
         run: |
-          source ~/functions.sh
+          source github/functions.sh
 
           for chroot in ${{ env.chroots }}; do
             # Modify chroot to know about compat package repo and about the --with=snapshot_build option

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -56,7 +56,7 @@ jobs:
           # Check if yesterday's project exists and all builds succeeded
           yesterdays_project_exists=`project_exists ${{ env.project_yesterday }}`
           if [[ "$yesterdays_project_exists" == "true" ]]; then
-            if has_not_succeeded_builds ${{env.project_yesterday}}; then
+            if ! has_all_good_builds ${{env.project_yesterday}}; then
               yesterdays_project_exists=false
             fi
           fi

--- a/README.adoc
+++ b/README.adoc
@@ -37,11 +37,7 @@ This workflow contains `copr` CLI calls that are needed in order to:
 --
 NOTE: Replace `<YYYYMMDD>` with a date in reversed year month day order (e.g. `20230223`).
 --
-2. Take the snapshots from yesterday and make them available ("fork" in Copr) under link:https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots/monitor/[@fedora-llvm-team/llvm-snapshots]
-+
---
-NOTE: See the section <<wave-through>> to learn the prerequisites for yesterday's build to become the new `@fedora-llvm-team/llvm-snapshots`.
---
+2. Take the snapshots from yesterday and make them available ("fork" in Copr) under link:https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots/monitor/[@fedora-llvm-team/llvm-snapshots], if all builds succeeded.
 
 When you repeat these two steps every day, you get a project for each day with with `@fedora-llvm-team/llvm-snapshots` "pointing to" the build from yesterday.
 
@@ -149,28 +145,6 @@ history of downstream patches and changes being made to a `.spec` file.
 IMPORTANT: That is why we almost always prefer `git merge --no-ff --log --summary` over `git rebase`.
 
 == Frequently Asked Questions [[faq]]
-
-=== How to manually wave a build through? [[wave-through]]
-
-It can happen at any day that there's an error with LLVM upstream which prevents it from being compilable or testable. When this happens, you don't want the Copr project `@fedora-llvm-team/llvm-snapshots` to be overwritten with broken builds. That is why we manually have to wave today's project through.
-
-1. Open the snapshot build monitor for the current day:
-+
-----
-xdg-open https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-incubator-`date +%Y%m%d`/monitor
-----
-
-2. Check if you like what you see and if there's not "too much" red as in failed builds, click the btn:[Settings] tab/button in the menu bar for your project.
-
-3. Find the Description field and remove this from the description:
-+
-----
-REMOVE THIS LINE TO WAVE THIS BUILD THROUGH
-----
-
-4. Scroll down and hit the btn:[Update] button.
-
-5. At the next midnight build job, this day will be automatically forked into the `@fedora-llvm-team/llvm-snapshots` project (see <<overview>>).
 
 === What git remotes do I need? [[git-remotes]]
 

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -14,3 +14,9 @@ function get_active_build_ids(){
     | grep --perl-regexp --regexp='(running|waiting|pending|importing|starting)' \
     | cut -f 1
 }
+
+function has_not_succeeded_builds(){
+  local project=$1;
+  copr monitor --output-format text-row $project \
+    | grep -v succeeded
+}

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -1,0 +1,16 @@
+set -x
+# set -e
+# TODO(kwk): Is there a better way to check project existence?
+# TODO(kwk): Maybe: copr list $username | grep --regexp="^Name: \$project$"
+function project_exists(){
+  local project=$1;
+  copr get-chroot $project/fedora-rawhide-x86_64 > /dev/null 2>&1 \
+  && echo "true" || echo "false";
+}
+
+function get_active_build_ids(){
+  local project=$1;
+  copr list-builds --output-format text-row $project \
+    | grep --perl-regexp --regexp='(running|waiting|pending|importing|starting)' \
+    | cut -f 1
+}

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -25,7 +25,7 @@ function get_packages() {
   echo "python-lit llvm clang lld compiler-rt libomp"
 }
 
-# Returns true if a package needs special handling on certain architectures
+# Returns false if a package needs special handling on certain architectures
 function is_package_supported_by_chroot() {
   local pkg=$1;
   local chroot=$2;

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -1,4 +1,4 @@
-set -x
+set +x
 # set -e
 # TODO(kwk): Is there a better way to check project existence?
 # TODO(kwk): Maybe: copr list $username | grep --regexp="^Name: \$project$"
@@ -15,8 +15,43 @@ function get_active_build_ids(){
     | cut -f 1
 }
 
-function has_not_succeeded_builds(){
+# Prints the chroots we care about.
+function get_chroots() {
+  copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)' | tr '\n' ' '
+}
+
+# Prints the packages we care about
+function get_packages() {
+  echo "python-lit llvm clang lld compiler-rt libomp"
+}
+
+# Returns true if a package needs special handling on certain architectures
+function is_package_supported_by_chroot() {
+  local pkg=$1;
+  local chroot=$2;
+
+  if [[ ("$pkg" == "lld" || "$pkg" == "libomp") && $chroot =~ -s390x$ ]]; then
+    false
+  else
+    true
+  fi
+}
+
+# Returns 0 if all packages on all* chroots have successful builds.
+#
+# *: All supported combinations of package + chroot (see is_package_supported_by_chroot).
+function has_all_good_builds(){
   local project=$1;
-  copr monitor --output-format text-row $project \
-    | grep -v succeeded
+
+  copr monitor --output-format text-row --fields state,chroot,name $project | sort -k1 -k2 -k3 > /tmp/actual.txt
+  truncate -s 0 /tmp/expected.txt
+  for chroot in $(get_chroots); do
+    for package in $(get_packages) llvm-snapshot-builder; do
+      if is_package_supported_by_chroot "$package" "$chroot"; then
+        echo "succeeded $chroot $package" >> /tmp/expected.txt
+      fi
+    done
+  done
+  sort -k1 -k2 -k3 -o /tmp/expected.txt /tmp/expected.txt
+  diff -bus /tmp/expected.txt /tmp/actual.txt
 }

--- a/project-description.md
+++ b/project-description.md
@@ -1,5 +1,3 @@
-REMOVE THIS LINE TO WAVE THIS BUILD THROUGH
-
 This project provides Fedora packages for daily snapshot builds of [LLVM](https://www.llvm.org) projects
 such as [clang](https://clang.llvm.org/), [lld](https://lld.llvm.org/) and many more.
 


### PR DESCRIPTION
Automatically fork yesterday's snapshot incubator if all builds in it succeeded (as defined by the monitor page -- i.e. builds succeeding after resubmits is fine).

This matches the criterion for our current manual wave through, which has become something of a PITA (as builds only finish after working hours).