### PR TITLE
Fix --after-build-id if some builds are skipped

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -157,9 +157,9 @@ jobs:
                   --chroot ${chroot} \
                   ${{ env.project_today }} \
                   | tee ${pkg}.log
-              fi
 
-              after_build_id="--after-build-id `cat ${pkg}.log | grep -Po 'Created builds: \K(\d+)'`"
+                after_build_id="--after-build-id `cat ${pkg}.log | grep -Po 'Created builds: \K(\d+)'`"
+              fi
             done
           done
 


### PR DESCRIPTION
If we skip some of the builds, we should set --after-build-id to the last non-skipped build. Otherwise we end up running the build too early (after the llvm build for a different chroot, rather than the s390x chroot), which I believe is the cause for the common s390x compiler-rt failures we see.