### PR TITLE
Include yyymmdd in NVR of llvm-snapshot-builder

### DIFF
--- a/llvm-snapshot-builder/Makefile
+++ b/llvm-snapshot-builder/Makefile
@@ -5,8 +5,9 @@ SHELL := /bin/bash
 PACKAGE=$(shell basename $(CURDIR))
 TMP=$(CURDIR)/tmp
 SPECFILE=$(PACKAGE).spec
-YYYYMMDD_TODAY = $(shell date +%Y%m%d)
-VERSION=$(shell grep -Po 'Version:\s*\K(.*)' $(SPECFILE))
+YYYYMMDD_TODAY=$(shell date +%Y%m%d)
+GIT_REF=$(shell git rev-parse --short HEAD)
+VERSION=3.0.3~pre$(YYYYMMDD_TODAY).g$(GIT_REF)
 TARBALL=$(PACKAGE)-$(VERSION).tar.bz2
 FILES = README.md \
 		$(SPECFILE) \
@@ -36,14 +37,17 @@ source:
 	mkdir -p $(TMP)/$(PACKAGE)
 	cp -a $(FILES) $(TMP)/$(PACKAGE)
 	echo "%yyyymmdd $(YYYYMMDD_TODAY)" >> $(TMP)/$(PACKAGE)/macros.$(PACKAGE)
+	echo "Version: $(VERSION)" > $(TMP)/$(PACKAGE)/$(SPECFILE).tmp
+	cat $(TMP)/$(PACKAGE)/$(SPECFILE) >> $(TMP)/$(PACKAGE)/$(SPECFILE).tmp
+	mv $(TMP)/$(PACKAGE)/$(SPECFILE).tmp $(TMP)/$(PACKAGE)/$(SPECFILE)
 
 .PHONY: rpm
 rpm: tarball
-	rpmbuild --define '_topdir $(TMP)' -bb $(PACKAGE).spec
+	rpmbuild --define '_topdir $(TMP)' -bb $(TMP)/$(PACKAGE)/$(SPECFILE)
 
 .PHONY: srpm
 srpm: tarball
-	rpmbuild --define '_topdir $(TMP)' -bs $(PACKAGE).spec
+	rpmbuild --define '_topdir $(TMP)' -bs $(TMP)/$(PACKAGE)/$(SPECFILE)
 
 .PHONY: packit-srpm
 packit-srpm:

--- a/llvm-snapshot-builder/Makefile
+++ b/llvm-snapshot-builder/Makefile
@@ -40,6 +40,7 @@ source:
 	echo "Version: $(VERSION)" > $(TMP)/$(PACKAGE)/$(SPECFILE).tmp
 	cat $(TMP)/$(PACKAGE)/$(SPECFILE) >> $(TMP)/$(PACKAGE)/$(SPECFILE).tmp
 	mv $(TMP)/$(PACKAGE)/$(SPECFILE).tmp $(TMP)/$(PACKAGE)/$(SPECFILE)
+	sed -i '/^Version:\s*6\.6\.6/d' $(TMP)/$(PACKAGE)/$(SPECFILE)
 
 .PHONY: rpm
 rpm: tarball

--- a/llvm-snapshot-builder/llvm-snapshot-builder.spec
+++ b/llvm-snapshot-builder/llvm-snapshot-builder.spec
@@ -1,10 +1,9 @@
 Name:       llvm-snapshot-builder
-Version:    3.0.0
 Release:    1%{?dist}
 Summary:    A set of LUA functions used to build LLVM snaphots
 License:    BSD
 URL:        https://pagure.io/llvm-snapshot-builder
-Source0:    llvm-snapshot-builder-3.0.0.tar.bz2
+Source0:    %{name}-%{version}.tar.bz2
 BuildArch:  noarch
 Requires:   curl
 
@@ -12,7 +11,7 @@ Requires:   curl
 This package provides the llvm_sb macro for LLVM snaphot building.
 
 %prep
-%autosetup -n llvm-snapshot-builder
+%autosetup -n %{name}
 
 %build
 
@@ -23,6 +22,9 @@ install -p -m0644 -D macros.%{name} %{buildroot}%{_rpmmacrodir}/macros.%{name}
 %{_rpmmacrodir}/macros.%{name}
 
 %changelog
+* %{lua: print(os.date("%a %b %d %Y"))} LLVM snapshot - %{version}
+- This is an automated snapshot build
+
 * Thu Feb 23 2023 Konrad Kleine <kkleine@redhat.com> - 3.0.0-1
 - Bump version to be newer than what's currently in Copr @fedora-llvm-team/llvm-snapshot-builder
 

--- a/llvm-snapshot-builder/llvm-snapshot-builder.spec
+++ b/llvm-snapshot-builder/llvm-snapshot-builder.spec
@@ -1,4 +1,5 @@
 Name:       llvm-snapshot-builder
+Version:    6.6.6
 Release:    1%{?dist}
 Summary:    A set of LUA functions used to build LLVM snaphots
 License:    BSD


### PR DESCRIPTION
This adds the year month date to the NVR as well as the git revision,
just like in the snapshots.

To test, run these steps:

```console
$ cd llvm-snapshot-builder
$ make rpm
$ ls tmp/RPMS/noarch/
llvm-snapshot-builder-3.0.3~pre20230928.gdcb724d-1.fc38.noarch.rpm
```

Verify that your output contains the version like above or at least
similar.

Fixes: https://issues.redhat.com/browse/LLVM-43
