### PR TITLE
Increase height of diagrams

### DIFF
--- a/build-stats/create-diagrams.py
+++ b/build-stats/create-diagrams.py
@@ -67,7 +67,7 @@ def create_figure(df: pd.DataFrame, package_name: str) -> go.Figure:
     fig.update_traces(marker_size=7)
     fig.update_traces(textposition="bottom left")
     fig.update_xaxes(minor=dict(ticks="outside", showgrid=True))
-    fig.update_layout(yaxis_tickformat="%H:%M:%S")
+    fig.update_layout(yaxis_tickformat="%H:%M:%S", height=800)
 
     return fig
 


### PR DESCRIPTION
This should unclutter the vertical distribution of lines representing
chroots a bit. We're also able to view the legend as a whole and there's no more need to scroll.

Diagrams before:
![Bildschirmfoto vom 2023-10-12 11-40-50](https://github.com/kwk/llvm-daily-fedora-rpms/assets/193408/06dd5bf6-ebae-44ef-9a63-98d8be58ddc6)

Diagrams after
![Bildschirmfoto vom 2023-10-12 11-39-53](https://github.com/kwk/llvm-daily-fedora-rpms/assets/193408/556604eb-cbbf-40c2-8038-0e0f3742a7c3)

