### PR TITLE
Add missing --repo argument

### DIFF
--- a/github/functions.sh
+++ b/github/functions.sh
@@ -8,7 +8,8 @@ function yyyymmdd() {
 # Checks if there's an issue for a broken snapshot reported today
 function was_broken_snapshot_detected_today() {
   local d=`yyyymmdd`
-  gh issue list --label broken_snapshot_detected --state all | grep $d > /dev/null 2>&1
+  gh --repo ${GITHUB_REPOSITORY} issue list \
+    --label broken_snapshot_detected --state all | grep $d > /dev/null 2>&1
 }
 
 # Checks if a copr project exists


### PR DESCRIPTION
Otherwise it defaults to the current git checkout, while `actions/checkout` apparently just downloads the contents instead of creating a git repo in this action.