### PR TITLE
Pass a new "snapshot" context to tmt

### DIFF
--- a/.github/workflows/tmt.yml
+++ b/.github/workflows/tmt.yml
@@ -70,7 +70,16 @@ jobs:
 
             cd ${cur_dir}/${pkg}
             
-            tmt -c distro=${{ matrix.os }}-${{ matrix.version }} -c arch=x86_64 run -avv provision -h local -vv --log-topic cli-invocations report -vvv
+            # See https://src.fedoraproject.org/tests/llvm/pull-request/19 for
+            # the definition of the "snapshot" dimension
+            # (https://fmf.readthedocs.io/en/latest/context.html#dimensions).
+            tmt \
+              -c distro=${{ matrix.os }}-${{ matrix.version }} \
+              -c arch=x86_64 \
+              -c snapshot=${{env.today_yyyymmdd}} \
+              run --all -v \
+              provision --how local -v \
+              report -vvv
 
           done
 


### PR DESCRIPTION
This relates to
https://src.fedoraproject.org/tests/llvm/pull-request/19.

We don't built all LLVM packages as snapshot that are available in
Fedora. Therefore we must exclude certain packages from being installed.
When a LIT test runs that requires a package and it is not there, the
test will be unsupported and not cause errors.
