### PR TITLE
tmt: exclude ppc64le-long-double

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -26,6 +26,11 @@ discover:
       url: https://src.fedoraproject.org/tests/clang.git
       ref: main
       filter: "tag:-spoils-installation & tag:-not-in-default"
+      exclude:
+        # The following test only runs with qemu and we're executing in a github
+        # action runner in a container.
+        # See https://src.fedoraproject.org/tests/clang/blob/main/f/ppc64le-long-double/main.fmf#_19
+        - ppc64le-long-double
     - name: compiler-rt-tests
       how: fmf
       url: https://src.fedoraproject.org/tests/compiler-rt.git


### PR DESCRIPTION
Because it requires qemu and mock and we're running tmt inside a
container.

See https://src.fedoraproject.org/tests/clang/blob/main/f/ppc64le-long-double/main.fmf#_19
