### PR TITLE
stats: bring in big-merge

### DIFF
--- a/.github/workflows/update-build-time-diagrams.yml
+++ b/.github/workflows/update-build-time-diagrams.yml
@@ -42,13 +42,13 @@ jobs:
         with:
           ref: 'main'
           path: 'main'
-      
+
       - name: Checkout gh-pages branch
         uses: actions/checkout@v3
         with:
           ref: 'gh-pages'
           path: 'gh-pages'
-      
+
       - name: "Check for cached dependencies"
         uses: actions/cache@v3
         with:
@@ -71,20 +71,21 @@ jobs:
         shell: bash -e {0}
         env:
           get_stats: ${{ github.event_name == 'schedule' && true || github.event.inputs.get_stats }}
-          create_diagrams: ${{ github.event_name == 'schedule' && true || github.event.inputs.create_diagrams }} 
+          create_diagrams: ${{ github.event_name == 'schedule' && true || github.event.inputs.create_diagrams }}
         run: |
           if ${{ env.get_stats }}; then
-            main/build-stats/get-build-stats.py | tee -a gh-pages/build-stats.csv
-            git -C gh-pages add build-stats.csv
+            main/build-stats/get-build-stats.py --copr-projectname llvm-snapshots-incubator-$d | tee -a gh-pages/build-stats.csv
+            main/build-stats/get-build-stats.py --copr-projectname llvm-snapshots-big-merge-$d | tee -a gh-pages/build-stats-big-merge.csv
+            git -C gh-pages add build-stats.csv build-stats-big-merge.csv
           fi
           if ${{ env.create_diagrams }}; then
-            main/build-stats/create-diagrams.py --datafile gh-pages/build-stats.csv
+            main/build-stats/create-diagrams.py --datafile gh-pages/build-stats.csv --datafile-big-merge gh-pages/build-stats-big-merge.csv
             mv index.html gh-pages/index.html
             mv fig-*.html gh-pages/
             git -C gh-pages add index.html fig-*.html
           fi
           if [[ ${{ env.get_stats }} || ${{ env.create_diagrams }} ]]; then
             cd gh-pages
-            git commit -m "Automatically update stats build stats"
+            git commit -m "Automatically update build stats"
             git push origin HEAD:gh-pages
           fi

--- a/build-stats/create-diagrams.py
+++ b/build-stats/create-diagrams.py
@@ -324,7 +324,7 @@ def main() -> None:
     # Create dataframe of llvm, clang, compiler-rt and libomp combined in
     # standalone-mode
     df_combined = prepare_data_combined(
-        filepath=args.datafile_big_merge,
+        filepath=args.datafile,
         package_names=["llvm", "clang", "compiler-rt", "libomp"],
     )
 

--- a/build-stats/create-diagrams.py
+++ b/build-stats/create-diagrams.py
@@ -142,7 +142,9 @@ def add_html_header_menu(
             for package_name in all_packages
         ]
     )
-    header_menu += ' | <a href="fig-combined-standalone.html">llvm+clang+compiler-rt+libomp (standalone)</a>'
+    header_menu += (
+        ' | <a href="fig-combined-standalone.html">llvm+clang+compiler-rt+libomp</a>'
+    )
     header_menu += "</div>"
     header_menu += replace_me
 
@@ -248,7 +250,10 @@ def create_index_page(all_packages: [str], filepath: str = "index.html") -> None
         </head>
         <body>
             <h1>{title}</h1>
-            <ul>{package_link_items}</ul>
+            <ul>
+                {package_link_items}
+                <li><a href="fig-combined-standalone.html">llvm+clang+compiler-rt+libomp</a></li>
+            </ul>
             <hr/>
             <small>Last updated: {last_updated}</small>
         </body>
@@ -283,6 +288,13 @@ def main() -> None:
         default="build-stats.csv",
         help="path to your build-stats.csv file",
     )
+    parser.add_argument(
+        "--datafile-big-merge",
+        dest="datafile_big_merge",
+        type=str,
+        default="build-stats-big-merge.csv",
+        help="path to your build-stats-big-merge.csv file",
+    )
     args = parser.parse_args()
 
     # %%
@@ -309,11 +321,26 @@ def main() -> None:
         save_figure(fig=fig, filepath=filepath)
         add_html_header_menu(filepath=filepath, all_packages=all_packages)
 
-    # Create combined plot of llvm, clang, compiler-rt and openmp (aka libomp)
+    # Create dataframe of llvm, clang, compiler-rt and libomp combined in
+    # standalone-mode
     df_combined = prepare_data_combined(
-        filepath=args.datafile, package_names=["llvm", "clang", "compiler-rt", "libomp"]
+        filepath=args.datafile_big_merge,
+        package_names=["llvm", "clang", "compiler-rt", "libomp"],
     )
-    fig = create_figure(df=df_combined)
+
+    # Create dataframe of llvm, clang, compiler-rt and libomp but when build in
+    # big-merge mode. The chroots are suffixed with "-big-merge" on the fly to
+    # be able to distinguish the two cases.
+    df_big_merge = prepare_data(filepath=args.datafile_big_merge)
+    df_big_merge["chroot"] = "big-merge-" + df_big_merge["chroot"]
+    # Convert build_id column with int64's in it to an array of int64's to match
+    # that of the combined standalone dataframe above (see: df_combined).
+    df_big_merge.build_id = df_big_merge.build_id.apply(lambda x: [x])
+
+    # Concat the two dataframes of combined standalone and big-merge
+    df_result = pd.concat([df_combined, df_big_merge])
+
+    fig = create_figure(df=df_result)
     filepath = "fig-combined-standalone.html"
     save_figure(fig=fig, filepath=filepath)
     add_html_header_menu(filepath=filepath, all_packages=all_packages)


### PR DESCRIPTION
This add the big-merge builds to the llvm+clang+compiler-rt+libomp stats. You can distinguish the data because the chroots for the big-merge builds are prefixed with `big-merge-`. 

In this screenshots you can see the overall and zoomed comparison of build times for the standalone ones and the big-merge ones.

**overall**
![grafik](https://github.com/kwk/llvm-daily-fedora-rpms/assets/193408/100d314a-9115-48fa-b9d8-58d90a07aad8)

**zoomed**
![grafik](https://github.com/kwk/llvm-daily-fedora-rpms/assets/193408/f0dd16b9-56e9-443f-a329-aca8f4888de3)

You can clearly see in the zoomed screenshot, that the big-merge builds took roughly 9 minutes longer. Keep in mind, this is just showing the build time and not the runtime impact of the big-merge builds which might potentially be better.

In the big-merge builds we run tests for openmp and probably many other ones that are not executed in the standalone builds. Therefore, we shouldn't base our judgement about the big-merge builds solely on just these graphs. In fact, once we introduce bootstrap builds or PGO, we should expect the build time performance to decrease significantly.