### PR TITLE
Fix promotion check

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -75,7 +75,10 @@ jobs:
           # Check if yesterday's project exists and all builds succeeded
           yesterdays_project_exists=`project_exists ${{ env.project_yesterday }}`
           if [[ "$yesterdays_project_exists" == "true" ]]; then
-            if ! has_all_good_builds ${{env.project_yesterday}}; then
+            if [ "${{ matrix.needs_llvm_snapshot_builder }}" == "true" ]; then
+              extra_packages=llvm-snapshot-builder
+            fi
+            if ! has_all_good_builds ${{env.project_yesterday}} $extra_packages; then
               yesterdays_project_exists=false
             fi
           fi


### PR DESCRIPTION
https://github.com/kwk/llvm-daily-fedora-rpms/commit/3119eda358a47007be7c8c50951e16550cee298f added a new parameter to has_all_good_builds, but only passes it in check-todays-snapshot.yml, but not fedora-copr-build.yml. For that reason, we always get a diff due to extra llvm-snapshot-builder lines and don't promote the successful snapshot build.