### PR TITLE
Automatically identify build failure causes

### DIFF
--- a/.github/workflows/check-todays-snapshot.yml
+++ b/.github/workflows/check-todays-snapshot.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Copr CLI
         run: |
-          dnf install -y copr-cli diffutils
+          dnf install -y copr-cli diffutils pcre2-tools
 
       - uses: actions/checkout@v3
 
@@ -74,16 +74,35 @@ jobs:
           source github/functions.sh
           [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
-          if was_broken_snapshot_detected_today ${{ matrix.name }}; then
-            echo "We already filed an issue for broken snapshots today."
+          # This function inspects causes of build errors and adds a comment to
+          # today's issue.
+          function handle_error_causes() {
+            local causes_file=$1
+            local issue_number=`todays_issue_number ${GITHUB_REPOSITORY} ${{ matrix.name }}`
+            local error_labels=""
+            local comment_file=`mktemp`
+
             echo "Maybe we can identify new causes for errors by inspecting the build logs."
 
-            issue_number=`todays_issue_number ${{ matrix.name }}`
-            for error_cause in `list_error_causes ${{ env.project_today }}`; do
-              gh --repo ${GITHUB_REPOSITORY} label create error/$error_cause --force
-              gh --repo ${GITHUB_REPOSITORY} issue edit --add-label $issue_number error/$error_cause"
-            done
+            # If no error causes file was passed, process build logs to get
+            # error causes. Also ensure the error cause labels are created.
+            if [[ -n "$causes_file" && ! -f "$causes_file" ]]; then
+              causes_file=`mktemp`
+              error_causes=`list_error_causes ${{ env.project_today }} $causes_file`
+              create_labels_for_error_causes ${GITHUB_REPOSITORY} $error_causes
+            fi
 
+            # Turn some error causes into their own comment.
+            report_build_issues \
+              ${GITHUB_REPOSITORY} \
+              $issue_number \
+              $causes_file \
+              ${{ matrix.maintainer_handle }}
+          }
+
+          if was_broken_snapshot_detected_today ${GITHUB_REPOSITORY} ${{ matrix.name }}; then
+            echo "We already filed an issue for broken snapshots today."
+            handle_error_causes
             exit 0;
           fi
 
@@ -107,39 +126,34 @@ jobs:
           $(cat /tmp/diff)
           \`\`\`
           EOF
+              causes_file=`mktemp`
 
               archs=`grep -ioP 'failed\s+[^-]+-[0-9,rawhide]+-\K[^\s]+' /tmp/diff | sort | uniq`
               projects=`grep -ioP 'failed\s+[^\s]+\s+\K[^\s]+$' /tmp/diff | sort | uniq`
               oses=`grep -ioP 'failed\s+\K.*' /tmp/diff | cut -d '-' -f 1-2 | sort | uniq`
+              error_causes=`list_error_causes ${{ env.project_today }} $causes_file`
 
-              # Ensure labels for OS, project and arch exist in github project
-              for arch in $archs; do
-                gh --repo ${GITHUB_REPOSITORY} label create arch/$arch --color "C5DEF5" --force;
-              done
-              for project in $projects; do
-                gh --repo ${GITHUB_REPOSITORY} label create project/$project --color "BFDADC" --force;
-              done
-              for os in $oses; do
-                gh --repo ${GITHUB_REPOSITORY} label create os/$os --color "F9D0C4" --force;
-              done
-              # Ensure label for strategy name exists in github project
-              gh --repo ${GITHUB_REPOSITORY} label create strategy/${{ matrix.name }} --color "FFFFFF" --force
+              # Ensure labels for arch, project, OS, strategy and error cause
+              # exist in the github project
+              create_labels_for_archs ${GITHUB_REPOSITORY} $archs
+              create_labels_for_projects ${GITHUB_REPOSITORY} $projects
+              create_labels_for_oses ${GITHUB_REPOSITORY} $oses
+              create_labels_for_strategies ${GITHUB_REPOSITORY} ${{ matrix.name }}
+              create_labels_for_error_causes ${GITHUB_REPOSITORY} $error_causes
 
               os_labels=`for os in $oses; do echo -n " --label os/$os "; done`
               arch_labels=`for arch in $archs; do echo -n " --label arch/$arch " ; done`
               project_labels=`for project in $projects; do echo -n " --label project/$project "; done`
-
-              error_labels=""
-              for error_cause in `list_error_causes ${{ env.project_today }}`; do
-                gh --repo ${GITHUB_REPOSITORY} label create error/$error_cause --force
-                error_labels="$error_labels --label error/$error_cause"
-              done
+              error_labels=`for cause in $error_causes; do echo -n " --label error/$cause "; done`
+              strategy_labels=" --label strategy/${{ matrix.name }} "
 
               gh --repo ${GITHUB_REPOSITORY} issue create \
-                --label broken_snapshot_detected --label strategy/${{ matrix.name }} $os_labels $arch_labels $project_labels $error_labels \
+                --label broken_snapshot_detected $strategy_labels $os_labels $arch_labels $project_labels $error_labels \
                 --assignee ${{ matrix.maintainer_handle }} \
                 --title "Broken snapshot for ${{ env.today_yyyymmdd }} detected (${{ matrix.name }})" \
                 --body-file body.txt
+
+                handle_error_causes $causes_file
 
               exit 1
             fi

--- a/.github/workflows/check-todays-snapshot.yml
+++ b/.github/workflows/check-todays-snapshot.yml
@@ -74,8 +74,16 @@ jobs:
           source github/functions.sh
           [[ ! -z "${{ matrix.extra_script_file }}" ]] && source ${{ matrix.extra_script_file }}
 
-          if was_broken_snapshot_detected_today; then
+          if was_broken_snapshot_detected_today ${{ matrix.name }}; then
             echo "We already filed an issue for broken snapshots today."
+            echo "Maybe we can identify new causes for errors by inspecting the build logs."
+
+            issue_number=`todays_issue_number ${{ matrix.name }}`
+            for error_cause in `list_error_causes ${{ env.project_today }}`; do
+              gh --repo ${GITHUB_REPOSITORY} label create error/$error_cause --force
+              gh --repo ${GITHUB_REPOSITORY} issue edit --add-label $issue_number error/$error_cause"
+            done
+
             exit 0;
           fi
 
@@ -121,11 +129,18 @@ jobs:
               arch_labels=`for arch in $archs; do echo -n " --label arch/$arch " ; done`
               project_labels=`for project in $projects; do echo -n " --label project/$project "; done`
 
+              error_labels=""
+              for error_cause in `list_error_causes ${{ env.project_today }}`; do
+                gh --repo ${GITHUB_REPOSITORY} label create error/$error_cause --force
+                error_labels="$error_labels --label error/$error_cause"
+              done
+
               gh --repo ${GITHUB_REPOSITORY} issue create \
-                --label broken_snapshot_detected --label strategy/${{ matrix.name }} $os_labels $arch_labels $project_labels \
+                --label broken_snapshot_detected --label strategy/${{ matrix.name }} $os_labels $arch_labels $project_labels $error_labels \
                 --assignee ${{ matrix.maintainer_handle }} \
                 --title "Broken snapshot for ${{ env.today_yyyymmdd }} detected (${{ matrix.name }})" \
                 --body-file body.txt
+
               exit 1
             fi
           fi

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install Copr CLI and required tools
         run: |
-          dnf install -y copr-cli make bzip2 rpm-build
+          dnf install -y copr-cli make bzip2 rpm-build pcre2-tools
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/update-build-time-diagrams.yml
+++ b/.github/workflows/update-build-time-diagrams.yml
@@ -19,7 +19,6 @@ on:
           required: false
           type: boolean
 
-
 jobs:
   update-build-time-diagrams:
     runs-on: ubuntu-latest

--- a/github/functions-big-merge.sh
+++ b/github/functions-big-merge.sh
@@ -31,3 +31,22 @@ function get_chroots() {
 function get_packages() {
   echo "llvm"
 }
+
+function get_chroots() {
+  copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)' | tr '\n' ' '
+}
+
+# Prefixes the old version of the given function with "_" to make it callable
+# from the overwrite.
+function overwrite_function() {
+  local function_name=$1
+  eval "_`declare -f $function_name`"
+}
+
+overwrite_function get_chroots
+function get_chroots() {
+  _get_chroots
+  echo -n "rhel-9-x86_64 "
+}
+
+get_chroots

--- a/github/functions-big-merge.sh
+++ b/github/functions-big-merge.sh
@@ -1,17 +1,6 @@
 # This file contains overwrite for the functions in functions.sh
 set +x
 
-# overwrite
-function was_broken_snapshot_detected_today() {
-  local d=`yyyymmdd`
-  gh --repo ${GITHUB_REPOSITORY} issue list \
-    --label broken_snapshot_detected \
-    --label strategy/big-merge \
-    --state all \
-    --search "$d" \
-  | grep -P "$d" > /dev/null 2>&1
-}
-
 # Prints the chroots we care about.
 prefix_function get_chroots
 function get_chroots() {

--- a/github/functions-big-merge.sh
+++ b/github/functions-big-merge.sh
@@ -1,13 +1,6 @@
 # This file contains overwrite for the functions in functions.sh
 set +x
 
-# Prefixes the old version of the given function with "_" to make it callable
-# from the overwriting function.
-function overwrite_function() {
-  local function_name=$1
-  eval "_`declare -f $function_name`"
-}
-
 # overwrite
 function was_broken_snapshot_detected_today() {
   local d=`yyyymmdd`
@@ -20,10 +13,10 @@ function was_broken_snapshot_detected_today() {
 }
 
 # Prints the chroots we care about.
-overwrite_function get_chroots
+prefix_function get_chroots
 function get_chroots() {
   _get_chroots
-  echo -n "rhel-9-x86_64 "
+  echo -n " rhel-9-x86_64 "
 }
 
 # Prints the packages we care about
@@ -31,22 +24,3 @@ function get_chroots() {
 function get_packages() {
   echo "llvm"
 }
-
-function get_chroots() {
-  copr list-chroots | grep -P '^fedora-(rawhide|[0-9]+)' | tr '\n' ' '
-}
-
-# Prefixes the old version of the given function with "_" to make it callable
-# from the overwrite.
-function overwrite_function() {
-  local function_name=$1
-  eval "_`declare -f $function_name`"
-}
-
-overwrite_function get_chroots
-function get_chroots() {
-  _get_chroots
-  echo -n "rhel-9-x86_64 "
-}
-
-get_chroots

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -309,3 +309,10 @@ function install_gh_client() {
   dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
   dnf install -y gh
 }
+
+# Prefixes the old version of the given function with "_" to make it callable
+# from the overwriting function.
+function prefix_function() {
+  local function_name=$1
+  eval "_`declare -f $function_name`"
+}

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -218,7 +218,7 @@ function list_error_causes(){
   done | sort | uniq
 }
 
-# Takes a file with error causes and promots unknown build causes as their own
+# Takes a file with error causes and promotes unknown build causes as their own
 # comment on the given issue.
 #
 # A causes file looks like a semicolon separated list file:

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -7,9 +7,10 @@ function yyyymmdd() {
 
 # Checks if there's an issue for a broken snapshot reported today
 function was_broken_snapshot_detected_today() {
-  local strategy=$1
+  local repo=$1
+  local strategy=$2
   local d=`yyyymmdd`
-  gh --repo ${GITHUB_REPOSITORY} issue list \
+  gh --repo $repo issue list \
     --label broken_snapshot_detected \
     --label strategy/$strategy \
     --state all \
@@ -19,15 +20,16 @@ function was_broken_snapshot_detected_today() {
 
 # Get today's issue. Make sure was_broken_snapshot_detected_today found one.
 function todays_issue_number() {
-  local strategy=$1
+  local repo=$1
+  local strategy=$2
   local d=`yyyymmdd`
-  gh --repo ${GITHUB_REPOSITORY} issue list \
+  gh --repo $repo issue list \
     --label broken_snapshot_detected \
     --label strategy/$strategy \
     --state all \
     --search "$d" \
     --json number \
-    | jq .[0].number
+    --jq .[0].number
 }
 
 # Checks if a copr project exists
@@ -94,38 +96,211 @@ function has_all_good_builds(){
   diff -bus /tmp/expected.txt /tmp/actual.txt
 }
 
+# Prints a comment on a given github issue that begins with an HTML comment
+# prefix in the form: <!--error/$cause project/$project chroot/$chroot-->.
+#
+# If no such comment exists, nothing is printed.
+#
+# Here's an example of what is printed.
+#
+#   {
+#     "author": {
+#       "login": "kwk"
+#     },
+#     "authorAssociation": "OWNER",
+#     "body": "<!--error_causes-->\r\nFoobar.",
+#     "createdAt": "2023-04-12T12:34:19Z",
+#     "id": "IC_123412341234",
+#     "includesCreatedEdit": true,
+#     "isMinimized": false,
+#     "minimizedReason": "",
+#     "reactionGroups": [],
+#     "url": "https://github.com/<USER>/<REPO>/issues/1#issuecomment-1505197645",
+#     "viewerDidAuthor": true
+#   }
+function get_error_cause_comment() {
+  local user_repo=$1
+  local issue_number=$2
+  local project=$3
+  local chroot=$4
+  local cause=$5
+
+  gh --repo $user_repo issue view $issue_number \
+    --comments \
+    --json comments \
+    --jq '.comments[] | select(.body | startswith("<!--error/'$cause' project/'$project' chroot/'$chroot'-->"))'
+}
+
+# Checks if a comment exists on a given github issue that begins with an HTML
+# comment prefix in the form:
+#   <!--error/$cause project/$project chroot/$chroot-->.
+function has_error_cause_comment() {
+  local user_repo=$1
+  local issue_number=$2
+  local project=$3
+  local chroot=$4
+  local cause=$5
+
+  comment=$(get_error_cause_comment $user_repo $issue_number $project $chroot $cause)
+  [[ -n "$comment" ]]
+}
+
 # For a given project this function prints causes for all cases of errors it can
-# automatically identify (e.g. copr_timeout or network_issue). The caller needs
-# to make sure the labels exists before attaching them to an issue.
+# automatically identify (e.g. copr_timeout, network_issue). The caller needs to
+# make sure the labels exists before adding them to an issue. If you pass an
+# additional file name, we will write every error cause with additional
+# information to it
+# (<cause>;<package_name>;<chroot>;<build_log_url>;<path_to_context_file>). The
+# context file contains the lines before and after the error in the build log.
 function list_error_causes(){
   local project=$1;
+  local causes_file=$2;
+  local grep_opts="-n --context=3"
+  local monitor_file=$(mktemp)
+  local context_file=$(mktemp)
+
+  [[ -n "$causes_file" ]] && truncate --size 0 $causes_file
 
   copr monitor \
-    --output-format text-row \
-    --fields state,url_build_log $project \
-    | grep -oP '^failed\K.*' \
-    > /tmp/failed_build_log_urls.txt
+    --output-format json \
+    --fields chroot,name,state,url_build_log $project \
+    > $monitor_file
 
+  cat $monitor_file | jq -r '.[] | select(.state | contains("failed")) | to_entries | map(.value) | @tsv' \
+  | while IFS=$'\t' read -r chroot package_name state build_log_url; do
+    # echo "state=$state package_name=$package_name chroot=$chroot build_log_url=$build_log_url";
 
-  while read -r url; do
     log_file=$(mktemp)
-    curl -sL $url | gunzip -c  > $log_file
+    curl -sL $build_log_url | gunzip -c  > $log_file
+
+    got_cause=0
+
+    function store_cause() {
+      local cause=$1
+      echo $cause
+      if [[ -n "$causes_file" ]]; then
+        echo "$cause;$package_name;$chroot;$build_log_url;$context_file" >> $causes_file
+        # For the next error we need to make room an create a new context file
+        context_file=$(mktemp)
+      fi
+      got_cause=1
+    }
 
     # Check for timeout
-    if [ ! -z "$(grep '!! Copr timeout' $log_file)" ]; then
-      echo "copr_timeout"
+    if [ -n "$(grep $grep_opts '!! Copr timeout' $log_file | tee $context_file)" ]; then
+      store_cause "copr_timeout"
     fi
 
     # Check for network issues
-    if [ ! -z "$(grep 'Errors during downloading metadata for repository' $log_file)" ]; then
-      echo "network_issue"
+    if [ -n "$(grep $grep_opts 'Errors during downloading metadata for repository' $log_file | tee $context_file)" ]; then
+      store_cause "network_issue"
     fi
 
-    # TODO: Feel free to add your check here...
+    # Check for dependency issues
+    if [ -n "$(grep $grep_opts 'Not all dependencies satisfied' $log_file | tee $context_file)" ]; then
+      store_cause "dependency_issue"
+    fi
+
+    # Check for test issues
+    if [ -n "$(pcre2grep -n --before-context=2 --after-context=10 -M 'Failed Tests.*(\n|.)*Total Discovered Tests:' $log_file | tee $context_file)" ]; then
+      store_cause "test"
+    fi
+
+    # TODO: Feel free to add your check here (make sure to set got_cause=1)...
+
+    if [ "$got_cause" == "0" ]; then
+      # Add the tail of the log to the context file because we haven't got any better information
+      tail -n 10 > $context_file
+      store_cause "unknown"
+    fi
 
     rm $log_file
-  done < /tmp/failed_build_log_urls.txt | sort | uniq
+  done | sort | uniq
 }
+
+# Takes a file with error causes and promots unknown build causes as their own
+# comment on the given issue.
+#
+# A causes file looks like a semicolon separated list file:
+#
+#  network_issue;llvm;fedora-rawhide-i386;https://download.copr.fedorainfracloud.org/results/@fedora-llvm-team/llvm-snapshots-big-merge-20240105/fedora-rawhide-i386/06865034-llvm/builder-live.log.gz;/tmp/tmp.v17rnmc4rp
+#  copr_timeout;llvm;fedora-39-ppc64le;https://download.copr.fedorainfracloud.org/results/@fedora-llvm-team/llvm-snapshots-big-merge-20240105/fedora-39-ppc64le/06865030-llvm/builder-live.log.gz;/tmp/tmp.PMXc0b7uEE
+function report_build_issues() {
+  local repo=$1
+  local issue_number=$2;
+  local causes_file=$3;
+  local maintainer_handle=$4;
+  local comment_body_file=""
+
+  while IFS=';' read -r cause package_name chroot build_log_url context_file;
+  do
+    echo "$cause $package_name $chroot $build_log_url $context_file"
+    if [ "$cause" == "network_issue" ]; then
+      if ! has_error_cause_comment $repo $issue_number $package_name $chroot $cause ; then
+        comment_body_file=$(mktemp)
+
+        cat <<EOF > $comment_body_file
+<!--error/$cause project/$package_name chroot/$chroot-->
+@maintainer_handle, package \`$package_name\` failed to build on \`$chroot\` for an unknown cause ([build-log]($build_log_url)):
+
+\`\`\`
+$(cat $context_file)
+\`\`\`
+EOF
+        gh --repo $repo issue comment $issue_number --body-file $comment_body_file
+        rm $comment_body_file
+      else
+        echo "error cause comment for project '$package_name' and '$chroot' and '$cause' already exists"
+      fi
+    fi
+  done < $causes_file
+}
+
+#region labels
+
+# Iterates over the given labels and creates or edits each label in the list
+# with the given prefix and color.
+function _create_labels() {
+  local repo=$1
+  local labels=$2
+  local label_prefix=$3
+  local color=$4
+
+  for label in $labels; do
+    gh --repo $repo label create $label_prefix$label --color $color --force
+  done
+}
+
+function create_labels_for_error_causes() {
+  local repo=$1
+  local error_causes=$2
+  _create_labels $repo $error_causes "error/" "F76B19"
+}
+
+function create_labels_for_archs() {
+  local repo=$1
+  local archs=$2
+  _create_labels $repo $archs "arch/" "C5DEF5"
+}
+
+function create_labels_for_oses() {
+  local repo=$1
+  local oses=$2
+  _create_labels $repo $oses "os/" "F9D0C4"
+}
+
+function create_labels_for_projects() {
+  local repo=$1
+  local projects=$2
+  _create_labels $repo $projects "project/" "BFDADC"
+}
+
+function create_labels_for_strategies() {
+  local repo=$1
+  local strategies=$2
+  _create_labels $repo $strategies "strategy/" "FFFFFF"
+}
+#endregion
 
 # This installs the gh client for Fedora as described here:
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md#fedora-centos-red-hat-enterprise-linux-dnf

--- a/github/functions.sh
+++ b/github/functions.sh
@@ -202,7 +202,7 @@ function list_error_causes(){
     fi
 
     # Check for test issues
-    if [ -n "$(pcre2grep -n --before-context=2 --after-context=10 -M 'Failed Tests.*(\n|.)*Total Discovered Tests:' $log_file | tee $context_file)" ]; then
+    if [ -n "$(pcre2grep -n --before-context=2 --after-context=10 -M '(Failed Tests|Unexpectedly Passed Tests).*(\n|.)*Total Discovered Tests:' $log_file | tee $context_file)" ]; then
       store_cause "test"
     fi
 


### PR DESCRIPTION
This allows us to continously monitor a given day for error causes.

When a new issue is created for a broken snapshot build, we'll check the
logs of the failing builds for anything that we identify as an error.
The errors we can identify so far are listed below. A github issue label (i.e. `error/copr_timeout`, `error/network_issue`) is then automatically added to the broken snapshot issue.

# Examples of error causes

## `copr_timeout`

<pre>
 <b>!! Copr timeout</b> => sending INT
WARNING: Machine 5851d3319caf45608112626e5dff90dc still running. Killing...
Copr build error: Build failed
</pre>

## `network_issue`

<pre>
<b>Errors during downloading metadata for repository</b> 'local':
  - Status code: 404 for https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64/repodata/c3262644a11234a683575d44416933749f6808ea60694a499b11336c3b735223-filelists.xml.gz (IP: 38.145.60.20)
  - Status code: 404 for https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64/repodata/729723bef89105229ca2204cb1fdb395e04630c92e8119a2a3eec1c70dcb1a62-primary.xml.gz (IP: 38.145.60.20)
Error: Failed to download metadata for repo 'local': Yum repo downloading error: Downloading error(s): repodata/729723bef89105229ca2204cb1fdb395e04630c92e8119a2a3eec1c70dcb1a62-primary.xml.gz - Cannot download, all mirrors were already tried without success; repodata/c3262644a11234a683575d44416933749f6808ea60694a499b11336c3b735223-filelists.xml.gz - Cannot download, all mirrors were already tried without success
</pre>

## `test_issue`

<pre>
PASS: lit :: shtest-define.py (73079 of 73079)
********************
<b>Failed Tests</b> (1):
  libarcher :: races/task-taskgroup-unrelated.c


Testing Time: 226.85s

<b>Total Discovered Tests:</b> 96435
  Skipped          :    50 (0.05%)
  Unsupported      :  2416 (2.51%)
  Passed           : 93787 (97.25%)
  Expectedly Failed:   181 (0.19%)
  Failed           :     1 (0.00%)
</pre>

## `dependency_issue`

<pre>
No matching package to install: 'llvm-googletest = 18.0.0~pre20240108.g60c4f82d3c4e9c'
No matching package to install: 'llvm-static = 18.0.0~pre20240108.g60c4f82d3c4e9c'
No matching package to install: 'llvm-test = 18.0.0~pre20240108.g60c4f82d3c4e9c'
<b>Not all dependencies satisfied</b>
Error: Some packages could not be found.
WARNING: DNF command failed, retrying, attempt #2, sleeping 10s
No matches found for the following disable plugin patterns: local, spacewalk, versionlock
</pre>

## `unknown`

Anything that we cannot identify as one of the above error causes will be classified as `unknown`. Those are probably the most interesting errors to look into. That is why this change materializes the tail of the build log as a comment on the issue related to a broken snapshot.