### PR TITLE
Set label colors

### DIFF
--- a/.github/workflows/check-todays-snapshot.yml
+++ b/.github/workflows/check-todays-snapshot.yml
@@ -105,11 +105,17 @@ jobs:
               oses=`grep -ioP 'failed\s+\K.*' /tmp/diff | cut -d '-' -f 1-2 | sort | uniq`
 
               # Ensure labels for OS, project and arch exist in github project
-              for arch in $archs; do gh --repo ${GITHUB_REPOSITORY} label create arch/$arch --force; done
-              for project in $projects; do gh --repo ${GITHUB_REPOSITORY} label create project/$project --force; done
-              for os in $oses; do gh --repo ${GITHUB_REPOSITORY} label create os/$os --force; done
+              for arch in $archs; do
+                gh --repo ${GITHUB_REPOSITORY} label create arch/$arch --color "#C5DEF5" --force;
+              done
+              for project in $projects; do
+                gh --repo ${GITHUB_REPOSITORY} label create project/$project --color "#BFDADC" --force;
+              done
+              for os in $oses; do
+                gh --repo ${GITHUB_REPOSITORY} label create os/$os --color "#F9D0C4" --force;
+              done
               # Ensure label for strategy name exists in github project
-              gh --repo ${GITHUB_REPOSITORY} label create strategy/${{ matrix.name }} --force
+              gh --repo ${GITHUB_REPOSITORY} label create strategy/${{ matrix.name }} --color "#FFFFFF" --force
 
               os_labels=`for os in $oses; do echo -n " --label os/$os "; done`
               arch_labels=`for arch in $archs; do echo -n " --label arch/$arch " ; done`


### PR DESCRIPTION
Set label colors for arch/project/os/strategy labels. I set the colors manually yesterday so we have one color for reach label kind, but apparently they get re-set every time the labels are re-created. This means we basically get a new random label color every day :)

Fix this by explicitly passing `--color`. The chosen colors are from GitHub's standard set in the light variant.