### PR TITLE
Disable fail-fast

### DIFF
--- a/.github/workflows/check-todays-snapshot.yml
+++ b/.github/workflows/check-todays-snapshot.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check-todays-snapshot:
     strategy:
+      fail-fast: false
       matrix:
         name: [standalone, big-merge, bootstrap]
         include:

--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build-on-copr:
     strategy:
+      fail-fast: false
       matrix:
         name: [standalone, big-merge, bootstrap]
         include:


### PR DESCRIPTION
The fedora-copr-build and check-todays-snapshot workflows currently use the (default-enabled) fail-fast mode, which means that if one matrix job fails (e.g. currently "bootstrap" is broken), then we're also going to fail the others. This is why snapshot builds did not get started today.

I don't think this is the behavior we want -- we'd like the different snapshot configs to run independently.

See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures for docs.