### PR TITLE
tarball-generation: find good commit again

### DIFF
--- a/.github/workflows/generate-snapshot-tarballs.yml
+++ b/.github/workflows/generate-snapshot-tarballs.yml
@@ -96,18 +96,25 @@ jobs:
           # remove with hack below
           fetch-depth: 1
 
-      # - name: "determine last stable commit of llvm/llvm-project"
-      #   id: stable-commit
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     sha=`llvm-daily-fedora-rpms/github/get-good-commit.py --token ${{ secrets.GITHUB_TOKEN }} --project "llvm/llvm-project" --start-ref main --ensure-checks clang-x86_64-debian-fast llvm-clang-x86_64-expensive-checks-debian --max-tries 400`
-      #     echo "sha=$sha" >> $GITHUB_ENV
-
-      - name: "hack(just use main): determine last stable commit of llvm/llvm-project"
+      - name: "determine last stable commit of llvm/llvm-project"
         id: stable-commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "sha=main" >> $GITHUB_ENV
+          llvm-daily-fedora-rpms/github/get-good-commit.py \
+            --token ${{ secrets.GITHUB_TOKEN }} \
+            --project "llvm/llvm-project" \
+            --start-ref main \
+            --ensure-checks \
+              clang-x86_64-debian-fast \
+              llvm-clang-x86_64-expensive-checks-debian \
+            --max-tries 400 > good_commit.sha
+          echo "sha=`cat good_commit.sha`" >> $GITHUB_ENV
+
+      # - name: "hack(just use main): determine last stable commit of llvm/llvm-project"
+      #   id: stable-commit
+      #   run: |
+      #     echo "sha=main" >> $GITHUB_ENV
 
       - name: "fetch stable revision to archive"
         run: git -C llvm-project fetch --depth=1 --no-tags origin ${{ env.sha }}

--- a/.github/workflows/generate-snapshot-tarballs.yml
+++ b/.github/workflows/generate-snapshot-tarballs.yml
@@ -107,7 +107,6 @@ jobs:
             --start-ref main \
             --ensure-checks \
               clang-x86_64-debian-fast \
-              llvm-clang-x86_64-expensive-checks-debian \
             --max-tries 400 > good_commit.sha
           echo "sha=`cat good_commit.sha`" >> $GITHUB_ENV
 

--- a/.github/workflows/generate-snapshot-tarballs.yml
+++ b/.github/workflows/generate-snapshot-tarballs.yml
@@ -107,7 +107,7 @@ jobs:
             --start-ref main \
             --ensure-checks \
               clang-x86_64-debian-fast \
-            --max-tries 400 > good_commit.sha
+            --max-tries 30 > good_commit.sha
           echo "sha=`cat good_commit.sha`" >> $GITHUB_ENV
 
       # - name: "hack(just use main): determine last stable commit of llvm/llvm-project"

--- a/build-stats/create-diagrams.py
+++ b/build-stats/create-diagrams.py
@@ -51,7 +51,7 @@ def create_figure(df: pd.DataFrame, package_name: str = None) -> go.Figure:
             "state": "State",
             "build_id": "Copr Build ID",
             "package": "LLVM subpackage",
-        }
+        },
         # text="build_time", # To show text at each location
     )
 

--- a/github/get-good-commit.py
+++ b/github/get-good-commit.py
@@ -9,10 +9,13 @@ def get_good_commit(
     token: str, project: str, start_ref: str, max_tries: int, ensure_checks: list[str]
 ) -> str:
     """
-    Takes a github project and walks up the list of first parents beginning at
-    `start_ref` until a "good" git commit is found. For a git commit to be good,
-    the combined status of the git commit must be "success" and all the checks
-    in `ensure_checks` must have run for the commit.
+    Takes a github project and walks up the chain of commits beginning with
+    `start_ref`. From there it checks the combined status of `max_tries` parent
+    commits. All the checks in `ensure_checks` must have run for the commit to
+    be considered the best of the `max_tries` commits. If among the `max_tries`
+    commits there are multiples commits that have a successful combined status,
+    the one is picked that passes all tests from `ensure_checks` and has the
+    most overall checks run.
 
     See also: https://docs.github.com/en/rest/reference/repos#get-the-combined-status-for-a-specific-reference
 
@@ -26,46 +29,53 @@ def get_good_commit(
     repo = g.get_repo(project)
     sha = start_ref
 
-    print("Scanning for good commit", file=sys.stderr)
+    print("Scanning for best of commit", file=sys.stderr)
     print("Project:   {}".format(project), file=sys.stderr)
-    print("Start Ref: {}".format(start_ref), file=sys.stderr)
-    print("Max Tries: {}".format(max_tries), file=sys.stderr)
+    print("Start ref: {}".format(start_ref), file=sys.stderr)
+    print("Max tries: {}".format(max_tries), file=sys.stderr)
     print("Checks:    {}".format(ensure_checks), file=sys.stderr)
+
+    max_check_runs = 0
+    best_commit = ""
+
     for i in range(0, max_tries):
         commit = repo.get_commit(sha=sha)
         combined_status = commit.get_combined_status().state
         print(
-            "{}. Combined Status for {} = {}".format(i, commit, combined_status),
+            "{}. Combined status for {} = {}".format(i, commit.sha, combined_status),
             file=sys.stderr,
         )
+
+        # move on with first parent if combined status is not successful
         if combined_status != "success":
-            # move on with first parent if combined status is not successful
             sha = commit.parents[0].sha
             continue
 
         statuses = commit.get_statuses()
+        num_check_runs = len(list(statuses))
+        print("    #check runs: {}".format(num_check_runs), file=sys.stderr)
+
         checks = ensure_checks.copy()
         for status in statuses:
             if status.context in checks:
                 print(
-                    "  * Status: {} - {}".format(status.context, status.description),
+                    "    * Status: {} - {}".format(status.context, status.description),
                     file=sys.stderr,
                 )
                 checks.remove(status.context)
-        if len(checks) != 0:
-            sha = commit.parents[0].sha
+
+        if len(checks) == 0 and (num_check_runs > max_check_runs):
+            best_commit = sha
+            max_check_runs = num_check_runs
             print(
-                "  Not all checks found. Continue with parent commit: {}".format(sha),
+                "    New best commit: sha {} (#check runs={})".format(
+                    sha, max_check_runs
+                ),
                 file=sys.stderr,
             )
-            continue
+        sha = commit.parents[0].sha
 
-        print("SUCCESS: First stable commit: {}".format(sha), file=sys.stderr)
-        return sha
-    print(
-        "ERROR: No good commit found after {} tries".format(max_tries), file=sys.stderr
-    )
-    return ""
+    return best_commit
 
 
 def main():
@@ -105,12 +115,9 @@ def main():
         dest="ensure_checks",
         metavar="CHECK",
         nargs="+",
-        default=[
-            "clang-x86_64-debian-fast",
-            "llvm-clang-x86_64-expensive-checks-debian",
-        ],
+        default=["clang-x86_64-debian-fast"],
         type=str,
-        help="list check names that must have run (default: clang-x86_64-debian-fast, llvm-clang-x86_64-expensive-checks-debian)",
+        help="list check names that must have run (default: clang-x86_64-debian-fast)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
We go over the last 30 commits and check if there's one that passes all of our required tests and that has a successful combined status. From all the successful commits we'll choose the one that has the most other checks passing without explicitly looking at the kind of checks.

The idea is to not build commits in our snapshots that are known to be broken. By limiting the number of commits to 30 we should stay within the boundaries of the day and not go too far back.

The output of `get-good-commit.py` is now split in two: `stdout` and `stderr` for us to get good logs on `stderr` and also get the final output commit SHA on `stdout`. Here's an example run of the script:

```console
$ ./get-good-commit.py --token <GITHUB_TOKEN> --max-tries 30  --start-ref 7b7d2dd7e3e42c941338edcd5dbc2ff0e5426c28
Scanning for best of commit
Project:   llvm/llvm-project
Start ref: 7b7d2dd7e3e42c941338edcd5dbc2ff0e5426c28
Max tries: 30
Checks:    ['clang-x86_64-debian-fast']
0. Combined status for 7b7d2dd7e3e42c941338edcd5dbc2ff0e5426c28 = failure
1. Combined status for e0e216099505bc5051ba53b2fdb8202cdde5f47e = pending
2. Combined status for e278c6709605f05c434d2f9f583122003c454293 = failure
3. Combined status for afa52de9f6def6a0de962401f9a6b34925f7010e = success
    Not all required checks have been run.
4. Combined status for 73874f7a39df74eacf1682b3961da2d8cb675f33 = success
    Not all required checks have been run.
5. Combined status for 035f33bf4138ac7b7360a83438988ce80bda5098 = failure
6. Combined status for f2d0bba8748137edc46ab88babcf83ceb23f68d2 = success
    * Status: clang-x86_64-debian-fast - Build done.
    New best commit: sha f2d0bba8748137edc46ab88babcf83ceb23f68d2 (#check runs=32)
7. Combined status for bb945fcd4a54c2c8f898e2bdc0d65fae841a1909 = success
    Ignoring commit because number of check runs (16) is below or equal current best (32)
8. Combined status for 1b7b40bf5d6847623e2737d4fe7b31a434195852 = failure
9. Combined status for 89cd345667a5f8f4c37c621fd8abe8d84e85c050 = failure
10. Combined status for 5cf9f2cd9888feea23a624c1de3cc37ce8ce8112 = failure
11. Combined status for d407e6ca61a422f25841674d8f0b5ea0dbec85f8 = success
    Ignoring commit because number of check runs (30) is below or equal current best (32)
12. Combined status for 731c2049a4fa3a8704df6b82311948a1ed8de5a6 = failure
13. Combined status for 65fd05517fe19bb436432ca45c03b7e576a328b5 = failure
14. Combined status for 6ccb06a7abc2062c72267bb7054502ae7db8cb82 = failure
15. Combined status for 550f0eb2ce12435b696b6c2a5fcbede8f6db68b1 = failure
16. Combined status for 28ee54c32e6b761e65fd2a7412776f6300ad922b = failure
17. Combined status for 5e9f0e37494ab42ff8d850527c5517f3006e63e9 = failure
18. Combined status for bf716fb7169b500a7fe3f20a39ac0288fb13cac5 = failure
19. Combined status for d4c01714239e80d21e441c3886749fc56b743f81 = failure
20. Combined status for 659a217b91a93869b6399fb85e24722a524c9d95 = pending
21. Combined status for 0ab539fd6748adf2f638e10514dd9419597d8863 = failure
22. Combined status for b64c26f34f6d64eb15bd7584623b37d1a8e0e5d5 = success
    Ignoring commit because number of check runs (8) is below or equal current best (32)
23. Combined status for 1bc1dcf28f41fc28c38e00d8d709eabe07751e14 = failure
24. Combined status for 46dd8acf36109c421443bcc4238dad3de5939acb = success
    * Status: clang-x86_64-debian-fast - Build done.
    New best commit: sha 46dd8acf36109c421443bcc4238dad3de5939acb (#check runs=36)
25. Combined status for 821dee98526057286ec2161b3c40ad6676b5377f = failure
26. Combined status for 11d76fdb0b9c500aace938427bba18602d15b17d = success
    Ignoring commit because number of check runs (14) is below or equal current best (36)
27. Combined status for c23608b8d58bdeb0134d99168e6d0335da2c8366 = failure
28. Combined status for 3ed98cb3de303c316c943da7d60b48472f7efdec = success
    Ignoring commit because number of check runs (30) is below or equal current best (36)
29. Combined status for fb8eb4251ac0ac27ab0125caf1abe3dbb93732f4 = failure
46dd8acf36109c421443bcc4238dad3de5939acb
```
