### PR TITLE
Use unpriviledged user in mass rebuild container

### DIFF
--- a/Containerfile.mass-rebuild
+++ b/Containerfile.mass-rebuild
@@ -13,11 +13,17 @@ RUN dnf -y copr enable tstellar/fedora-clang-default-cc
 
 RUN dnf -y install jq cmake ninja-build git binutils-devel clang fedora-clang-default-cc rpmbuild ccache
 
-WORKDIR /root
+RUN useradd -m rebuild-user
+
+RUN echo 'rebuild-user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER rebuild-user
+
+WORKDIR /home/rebuild-user
 
 RUN git clone https://github.com/llvm/llvm-project
 
-WORKDIR /root/llvm-project
+WORKDIR /home/rebuild-user/llvm-project
 
 ADD bisect.sh git-bisect-script.sh .
 

--- a/scripts/bisect.sh
+++ b/scripts/bisect.sh
@@ -44,12 +44,12 @@ function test_with_copr_builds {
   copr_project=$1
   srpm_name=$2
 
-  dnf remove -y clang llvm
-  dnf copr enable -y $copr_project
-  dnf install --best -y clang llvm
-  dnf builddep -y $srpm_name
+  sudo dnf remove -y clang llvm
+  sudo dnf copr enable -y $copr_project
+  sudo dnf install --best -y clang llvm
+  sudo dnf builddep -y $srpm_name
   # Disable project so future installs don't use it.
-  dnf copr disable $copr_project
+  sudo dnf copr disable $copr_project
   if ! rpmbuild -D '%toolchain clang' -rb $srpm_name; then
     return 1
   fi
@@ -113,7 +113,7 @@ srpm_name=$(find $(rpm --eval %{_srcrpmdir}) -iname '*.src.rpm')
 # We need to do this because the runtime repo dependencies from
 # the snapshot copr projects is not resolved when using dnf5 see:
 # https://github.com/fedora-copr/copr/issues/3387
-dnf copr enable -y @fedora-llvm-team/llvm-compat-packages
+sudo dnf copr enable -y @fedora-llvm-team/llvm-compat-packages
 
 # Test if the good commit still succeeds. A failure may indicate an
 # intermittent failure or an issue that is unrelated to LLVM. In either case,
@@ -156,7 +156,7 @@ while [ True ]; do
   fi
 done
 
-dnf builddep -y $srpm_name
+sudo dnf builddep -y $srpm_name
 git bisect start
 git bisect good $good_commit
 git bisect bad $bad_commit


### PR DESCRIPTION
Some packages, like vlc have tests that can't run as root.