### PR TITLE
Do not test mlir on fedora<=43 until it's enabled again

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -46,6 +46,15 @@ adjust:
         test: brp-llvm-compile-lto-elf
     when: distro > fedora-37
 
+  # TODO Remove after MLIR builds are enabled
+  # MLIR builds on fedora < 44 were disabled recently due to nanobind
+  # dependency version
+  - discover+:
+      adjust-tests:
+      - require-~:
+        - '^mlir'
+    when: distro <= fedora-43
+
 discover:
     - name: llvm-tests
       how: fmf


### PR DESCRIPTION
This commit will solve the issue where tmt downgrades the llvm from the snapshots to the repo version due to missing MLIR.
Example of this failure: https://artifacts.dev.testing-farm.io/adb6e5e3-2ffe-431b-8899-b19bfd03f6b2/work-snapshot-gatingkzzjmr8l/log.txt