### PR TITLE
Don't depend on build strategy for running flang tests

### DIFF
--- a/tests/snapshot-gating.fmf
+++ b/tests/snapshot-gating.fmf
@@ -49,8 +49,7 @@ adjust:
         url: https://src.fedoraproject.org/tests/flang.git
         ref: main
     when: >
-      build-strategy == with-flang
-        and distro ~>= fedora-44
+        distro ~>= fedora-44
         and arch == x86_64, ppc64le, aarch64
         and snapshot is defined
 


### PR DESCRIPTION
flang is now merged into rpms/llvm [1] and we can build it with the big-merge strategy as well.

[1]: https://src.fedoraproject.org/rpms/llvm/pull-request/483