### PR TITLE
Drop with-flang strategy

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -16,7 +16,6 @@ on:
         options:
         - all
         - big-merge
-        - with-flang
 
 jobs:
   generate-matrix:

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -191,19 +191,6 @@ def build_config_map() -> dict[str, Config]:
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],
         ),
-        Config(
-            build_strategy="with-flang",
-            copr_target_project="@fedora-llvm-team/llvm-snapshots-with-flang",
-            package_clone_url="https://src.fedoraproject.org/forks/kkleine/rpms/llvm.git",
-            package_clone_ref="flang",
-            maintainer_handle="kwk",
-            copr_project_tpl="llvm-snapshots-with-flang-YYYYMMDD",
-            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-with-flang-YYYYMMDD/monitor/",
-            chroot_pattern="^(fedora-rawhide)",
-            additional_copr_buildtime_repos=[
-                "copr://@fedora-llvm-team/llvm-test-suite/"
-            ],
-        ),
     ]
 
     return {config.build_strategy: config for config in configs}


### PR DESCRIPTION
We can drop the `with-flang` build strategy now.

I intentionally left it for today after [landing `flang`](https://src.fedoraproject.org/rpms/llvm/c/ee920d4db95425b764c576fa7ad97b3ae86038fb?branch=rawhide) in the `rpms/llvm` repository so that I can see if any error happening today failed in my branch (with-flang strategy) or in big-merge as well.

The packaging error appeared in both build strategies (https://github.com/fedora-llvm-team/llvm-snapshots/issues/1745#issuecomment-3466178323).