### PR TITLE
Upload paths matching: llvm*-YYYYMMDD.txt

### DIFF
--- a/scripts/upload-source-snapshots.py
+++ b/scripts/upload-source-snapshots.py
@@ -32,9 +32,7 @@ def main(args: argparse.Namespace) -> None:
         print(f"looking for source snapshots in directory: {dir}")
         glob_patterns = [
             "*-{}.src.tar.xz",
-            "llvm*-release-{}.txt",
-            "llvm*-rc-{}.txt",
-            "llvm*-git-revision-{}.txt",
+            "llvm*-{}.txt",
         ]
         for pattern in glob_patterns:
             for name in glob(pattern.format(yyyymmdd)):


### PR DESCRIPTION
Before the `llvm-test-suite-version-<YYYYMMDD>.txt` file wasn't uploaded.

Fixup for #1766