### PR TITLE
Add "run_check_snapshots_workflow" to config

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -73,6 +73,16 @@ jobs:
       matrix: ${{fromJson(needs.generate-matrix.outputs.mymatrix)}}
     runs-on: ubuntu-latest
     steps:
+      - name: Cancelling this workflow run if needed.
+        if: matrix.run_check_snapshots_workflow != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
       - name: Setup Copr config file
         if: github.event_name != 'workflow_dispatch' || (matrix.today_minus_n_days == 0 && inputs.strategy == matrix.name)
         env:

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -89,6 +89,9 @@ class Config:
     copr_package_name: str = "my-package"
     """ Name of the main package to build on Copr """
 
+    run_check_snapshots_workflow: bool = False
+    """ Turn this on if you want to run the 'check-snapshots.yml' workflow in github for this configuration """
+
     @property
     def copr_projectname(self) -> str:
         """Takes the copr_project_tpl and replaces the YYYYMMDD placeholder (if any) with a date.
@@ -156,6 +159,7 @@ class Config:
         ...   additional_copr_buildtime_repos=["copr://@fedora-llvm-team/llvm-test-suite", "https://example.com"],
         ...   spec_file="mypackage.spec",
         ...   copr_package_name="my-package",
+        ...   run_check_snapshots_workflow=True,
         ... ).to_github_dict())
         {'additional_copr_buildtime_repos': 'copr://@fedora-llvm-team/llvm-test-suite '
                                             'https://example.com',
@@ -172,6 +176,7 @@ class Config:
          'copr_target_project': '@mycoprgroup/mycoprproject',
          'maintainer_handle': 'fakeperson',
          'name': 'mybuildstrategy',
+         'run_check_snapshots_workflow': True,
          'spec_file': 'mypackage.spec'}
         """
         return {
@@ -191,6 +196,7 @@ class Config:
             "additional_copr_buildtime_repos": " ".join(
                 self.additional_copr_buildtime_repos
             ),
+            "run_check_snapshots_workflow": self.run_check_snapshots_workflow,
             "spec_file": self.spec_file,
         }
 
@@ -218,6 +224,7 @@ def build_config_map() -> dict[str, Config]:
             additional_copr_buildtime_repos=[
                 "copr://@fedora-llvm-team/llvm-test-suite/"
             ],
+            run_check_snapshots_workflow=True,
         ),
         Config(
             build_strategy="llvm-test-suite",
@@ -232,6 +239,7 @@ def build_config_map() -> dict[str, Config]:
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|centos-stream-[10,9]|rhel-8)",
             copr_project_description_file="llvm-test-suite-project-description.md",
             copr_project_instructions_file="llvm-test-suite-project-instructions.md",
+            run_check_snapshots_workflow=False,
         ),
     ]
 

--- a/snapshot_manager/snapshot_manager/util.py
+++ b/snapshot_manager/snapshot_manager/util.py
@@ -718,7 +718,8 @@ def serialize_config_map_to_github_matrix(
     ...   copr_project_tpl="SomeProjectTemplate-YYYYMMDD",
     ...   copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/mycoprgroup/SomeProjectTemplate-YYYYMMDD/monitor/",
     ...   chroot_pattern="^(fedora-(rawhide|[0-9]+)|rhel-[8,9]-)",
-    ...   chroots=["fedora-rawhide-x86_64", "rhel-9-ppc64le"]
+    ...   chroots=["fedora-rawhide-x86_64", "rhel-9-ppc64le"],
+    ...   run_check_snapshots_workflow=True,
     ... )
     >>> config_map["mybuildstrategy2"] = config.Config(build_strategy="mybuildstrategy2",
     ...   copr_target_project="@mycoprgroup2/mycoprproject2",
@@ -751,6 +752,7 @@ def serialize_config_map_to_github_matrix(
                   'copr_target_project': '@mycoprgroup/mycoprproject',
                   'maintainer_handle': 'fakeperson',
                   'name': 'mybuildstrategy',
+                  'run_check_snapshots_workflow': True,
                   'spec_file': 'my-package.spec'},
                  {'additional_copr_buildtime_repos': '',
                   'chroot_pattern': 'rhel-[8,9]',
@@ -766,6 +768,7 @@ def serialize_config_map_to_github_matrix(
                   'copr_target_project': '@mycoprgroup2/mycoprproject2',
                   'maintainer_handle': 'fakeperson2',
                   'name': 'mybuildstrategy2',
+                  'run_check_snapshots_workflow': False,
                   'spec_file': 'my-package.spec'}],
      'name': ['mybuildstrategy', 'mybuildstrategy2'],
      'today_minus_n_days': [0, 1, 2, 3]}


### PR DESCRIPTION
Then use this to check if we want to run the `check-snapshots.yml` workflow. For `llvm-test-suite` I don't want to create daily issues now. The main reason is that we don't have daily builds. We only build `llvm-test-suite` when things have changed.

The current system is designed to query for the daily copr repo and that would fail when we don't have daily builds.