### PR TITLE
Fix: Add actions:write permission to check-snapshots workflow

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -30,6 +30,8 @@ on:
 permissions:
   # We need this in order to create or update snapshot issues
   issues: write
+  # We need this in order to cancel workflow runs when needed
+  actions: write
 
 jobs:
   generate-matrix:


### PR DESCRIPTION
The workflow was failing with "HttpError: Resource not accessible by integration" when trying to cancel workflow runs. This is because the workflow only had issues:write permission but was attempting to call github.rest.actions.cancelWorkflowRun(), which requires actions:write.

Added actions:write permission to allow the workflow to cancel itself when matrix.run_check_snapshots_workflow != 'true'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Prompt: can you fix the error in this job https://github.com/fedora-llvm-team/llvm-snapshots/actions/runs/19375182014/job/55440775594