### PR TITLE
Treat a rare Testing Farm error

### DIFF
--- a/snapshot_manager/testing_farm/request.py
+++ b/snapshot_manager/testing_farm/request.py
@@ -169,7 +169,8 @@ class Request:
             request_file=request_file,
             request_id=request_id,
         )
-        # The xunit file is None, if it is only available internally.
+        # The xunit file is None if it is only available internally or if an
+        # infrastructure error happened.
         if xunit_file is None:
             return []
         return self.get_failed_test_cases_from_xunit_file(

--- a/snapshot_manager/testing_farm/tfutil.py
+++ b/snapshot_manager/testing_farm/tfutil.py
@@ -226,6 +226,10 @@ def get_xunit_file_from_request_file(
         raise KeyError("failed to find 'xunit_url' key in result dict response")
     xunit_url = result_json["result"]["xunit_url"]
 
+    # When there is a very early failure, xunit_url is unset.
+    if xunit_url is None:
+        return None
+
     # Get xunit file to log all testcases that have errors
     if not is_url_expectably_reachable(xunit_url):
         logging.info(


### PR DESCRIPTION
If an error happens very early, e.g. when discovering tests, the xunit_url is not set.
Ensure we do not crash in that scenario.