### PR TITLE
Stop forking the llvm-test-suite repository

### DIFF
--- a/.github/workflows/fedora-copr-build.yml
+++ b/.github/workflows/fedora-copr-build.yml
@@ -190,7 +190,7 @@ jobs:
           done
 
       - name: "Delete target Copr project at ${{ env.project_target }} before forking to it"
-        if: ${{ env.yesterdays_project_exists == 'yes' && env.target_project_exists == 'yes' }}
+        if: ${{ matrix.forked_repo && env.yesterdays_project_exists == 'yes' && env.target_project_exists == 'yes' }}
         run: |
           copr-cli delete "${{ env.project_target }}"
           # Give Copr some time to process the deletion, to avoid race conditions with forking.
@@ -198,7 +198,7 @@ jobs:
           sleep 1m
 
       - name: "Fork Copr project from ${{ env.project_yesterday }} to ${{ env.project_target }}"
-        if: ${{ env.yesterdays_project_exists == 'yes' }}
+        if: ${{ matrix.forked_repo && env.yesterdays_project_exists == 'yes' }}
         run: |
           copr-cli fork --confirm ${{ env.project_yesterday }} ${{ env.project_target }}
           copr-cli modify --delete-after-days -1 --unlisted-on-hp off ${{ env.project_target }}
@@ -206,6 +206,6 @@ jobs:
       - name: "Regenerate repos for target project ${{ env.project_target }}"
         # If yesterday's project didn't exist, we haven't forked and so we don't
         # need to regenerate the repos.
-        if: ${{ env.yesterdays_project_exists == 'yes' }}
+        if: ${{ matrix.forked_repo && env.yesterdays_project_exists == 'yes' }}
         run: |
           copr-cli regenerate-repos ${{ env.project_target }}

--- a/snapshot_manager/snapshot_manager/config.py
+++ b/snapshot_manager/snapshot_manager/config.py
@@ -58,6 +58,9 @@ class Config:
     copr_project_tpl: str = "llvm-snapshots-incubator-YYYYMMDD"
     """The Copr project name template of the project to work with. YYYYMMDD will be replace with the correct date"""
 
+    forked_repo: bool = True
+    """Indicates if project copr_project_tpl should be forked into copr_target_project. Otherwise, copr_project_tlp is treated as target repository"""
+
     copr_monitor_tpl: str = (
         "https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-incubator-YYYYMMDD/monitor/"
     )
@@ -217,6 +220,7 @@ def build_config_map() -> dict[str, Config]:
             package_clone_ref="rawhide",
             maintainer_handle="tbaederr",
             copr_project_tpl="llvm-snapshots-big-merge-YYYYMMDD",
+            forked_repo=True,
             copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-snapshots-big-merge-YYYYMMDD/monitor/",
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|centos-stream-[10,9]|rhel-8)",
             copr_project_description_file="llvm-project-description.md",
@@ -234,8 +238,9 @@ def build_config_map() -> dict[str, Config]:
             package_clone_url="https://src.fedoraproject.org/rpms/llvm-test-suite.git",
             package_clone_ref="rawhide",
             maintainer_handle="kkleine",
-            copr_project_tpl="llvm-test-suite-YYYYMMDD",
-            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-test-suite-YYYYMMDD/monitor/",
+            copr_project_tpl="llvm-test-suite",
+            forked_repo=False,
+            copr_monitor_tpl="https://copr.fedorainfracloud.org/coprs/g/fedora-llvm-team/llvm-test-suite/monitor/",
             chroot_pattern="^(fedora-(rawhide|[0-9]+)|centos-stream-[10,9]|rhel-8)",
             copr_project_description_file="llvm-test-suite-project-description.md",
             copr_project_instructions_file="llvm-test-suite-project-instructions.md",


### PR DESCRIPTION
Treat the llvm-test-suite repository differently by building its packages directly in the final repository, instead of creating a new repository that is forked into the final repository.

Fixes #1815.