### PR TITLE
Update sync-on-llvm-version workflow configuration

### DIFF
--- a/.github/workflows/sync-on-llvm-version.yml
+++ b/.github/workflows/sync-on-llvm-version.yml
@@ -5,6 +5,7 @@ on:
     # Everyday at 00:00am
     # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 permissions:
   # For release assets to be deletable we need this permission
@@ -52,11 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{github.event_name}}" == "workflow_dispatch"  ]]; then
-            commit_hash=${{inputs.commit_hash}}
-          else
-            commit_hash=${{ steps.good-commit.outputs.good-commit }}
-          fi
+          commit_hash=${{ steps.good-commit.outputs.good-commit }}
 
           if [[ "$commit_hash" =~ ^[0-9a-f]{40}$ ]]; then
             echo "commit_hash looks like a SHA1. No need to resolve: ${commit_hash}"


### PR DESCRIPTION
Removed workflow_dispatch input for commit_hash and reduced max-tries from 100 to 50.

The input wasn't used and it confused me when starting the workflow manually with a specific hash only to find out that a different hash was used. `main` is totally fine for now.

We previously ran into an API limit issue and to avoid this I've cut the max retries time in half.