### PR TITLE
Configuring multi-ecosystem updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
       - "pip"
       - "python"
     target-branch: "main"
-    reviewers:
-      - "kwk"
     patterns: ["*"]
     multi-ecosystem-group: "infrastructure"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,18 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "daily"
+    assignees:
+      - "kwk"
+    labels: ["infrastructure", "dependencies", "dependabot"]
+
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
     # Include a list of updated dependencies
     # with a prefix determined by the dependency group
     commit-message:
@@ -19,15 +26,15 @@ updates:
     labels:
       - "pip"
       - "python"
-      - "dependencies"
-      - "dependabot"
     target-branch: "main"
     reviewers:
       - "kwk"
-    assignees:
-      - "kwk"
+    patterns: ["*"]
+    multi-ecosystem-group: "infrastructure"
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+    patterns: ["*"]
+    labels:
+      - "github-actions"
+    multi-ecosystem-group: "infrastructure"


### PR DESCRIPTION
This should reduce the number of Dependabot pull requests we receive by grouping updates across multiple ecosystems into a single, consolidated pull request.

See [Configuring multi-ecosystem updates for Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-multi-ecosystem-updates)