### PR TITLE
Fix dependabot config error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,21 +12,21 @@ multi-ecosystem-groups:
     assignees:
       - "kwk"
     labels: ["infrastructure", "dependencies", "dependabot"]
+    target-branch: "main"
+    commit-message:
+      prefix: "prod"
+      prefix-development: "dev"
+      include: "scope"
 
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     # Include a list of updated dependencies
     # with a prefix determined by the dependency group
-    commit-message:
-      prefix: "pip prod"
-      prefix-development: "pip dev"
-      include: "scope"
     # Specify labels for pip pull requests
     labels:
       - "pip"
       - "python"
-    target-branch: "main"
     patterns: ["*"]
     multi-ecosystem-group: "infrastructure"
 


### PR DESCRIPTION
```
"commit-message" should only be set on the associated multi-ecosystem group, not directly on updates that are part of a multi-ecosystem update group.
"target-branch" should only be set on the associated multi-ecosystem group, not directly on updates that are part of a multi-ecosystem update group.
```

I saw the error here: https://github.com/fedora-llvm-team/llvm-snapshots/pull/2082/checks?check_run_id=78164591161