### PR TITLE
Extract doc files from downloaded RPMs

### DIFF
--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -69,12 +69,13 @@ function extract_srpm {
     popd
 }
 
-# Prints all files belonging to man page documentation from the fiven spec file
-# for a given RHEL version.
+# Writes all files belonging to man page documentation from the given spec file
+# for a given RHEL version to the given destination file list.
 function parse_spec_file_for_doc_files {
     local spec_file=${1:-${PWD}/srpm/llvm.spec}
     local rhel_version=${2:-UNDEFINED_RHEL_VERSION}
     local spec_dir
+    local dest_file_list=${3}
 
     echo "INFO: Parsing spec file ${spec_file} for doc files" 1>&2
     spec_dir=$(dirname "${spec_file}")
@@ -83,7 +84,23 @@ function parse_spec_file_for_doc_files {
         --undefine=fedora \
         --define="rhel ${rhel_version}" \
         -P llvm.spec 2>/dev/null \
-    | grep -P '^/usr/share/man'
+    | grep -P '^/usr/share/man' > "${dest_file_list}"
+    popd
+}
+
+# Extracts all files from the given rpm that are in the files list to the given
+# target directory.
+function extract_files_from_rpm {
+    local rpm=${1}
+    local target_dir=${2}
+    local files_list=${3:-doc-files.txt}
+
+    echo "INFO: Extracting files from ${rpm} in ${target_dir}" 1>&2
+    mkdir -p "${target_dir}"
+    pushd "${target_dir}"
+    # We actually do want files_list to split here.
+    # shellcheck disable=SC2046
+    rpm2cpio "${rpm}" | cpio -idm $(cat "${files_list}" | tr '\n' ' ')
     popd
 }
 
@@ -93,7 +110,8 @@ function main {
     local arch=x86_64
     local base_dir="${PWD}/package-rhel-docs"
     local rhel_version=${1:-9}
-    local doc_files=${base_dir}/doc_files.txt
+    local doc_files="${base_dir}/doc_files.txt"
+    local doc_files_cpio="${base_dir}/doc_files_cpio.txt"
 
     rawhide_tag=$(get_rawhide_tag)
     nvr=$(get_nvr "${rawhide_tag}")
@@ -106,7 +124,12 @@ function main {
     download_rpms "${nvr}" "noarch" "${base_dir}"
     download_srpm "${nvr}" "${base_dir}"
     extract_srpm "${base_dir}/${nvr}.src.rpm" "${base_dir}/srpm"
-    parse_spec_file_for_doc_files "${base_dir}/srpm/llvm.spec" "${rhel_version}" > "${doc_files}"
+    parse_spec_file_for_doc_files "${base_dir}/srpm/llvm.spec" "${rhel_version}" "${doc_files}"
+    echo "INFO: Prepending files in list with . to match cpio operation: ${doc_files_cpio}" 1>&2
+    sed -e 's/^/./' "${doc_files}" > "${doc_files_cpio}"
+    for rpm in "${base_dir}"/*.rpm; do
+        extract_files_from_rpm "${rpm}" "${base_dir}/install" "${doc_files_cpio}"
+    done
 }
 
 main

--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -5,7 +5,7 @@ set -e
 # This function ensures that all tools are installed.
 function check_tools {
     echo "INFO: Checking that all required tools are installed" 1>&2
-    which cpio koji bsdtar rpmspec rpm2cpio grep sed find tar
+    which cpio koji bsdtar rpmspec rpm2cpio grep sed find tar gpg centpkg
 }
 
 # Prints whatever tag is currently assigned to rawhide in koji (e.g. f45).
@@ -129,12 +129,23 @@ function verify_extracted_files {
 # file will be "<basename-of-archive-dir>.tar.xz".
 function create_archive_of_dir {
     local extracted_dir="${1}"
-    local target_archive=$(basename "${extracted_dir}").tar.xz
+    local target_archive
 
+    target_archive="${2:-$(basename "${extracted_dir}").tar.xz}"
     echo "INFO: Creating archive of ${extracted_dir} in ${target_archive}" 1>&2
     pushd "${extracted_dir}"
     tar -cJf "${target_archive}" .
     popd
+}
+
+# Creates a detached GPG signature from the given "<file>" and stores it under
+# "<file>.sig".
+function sign_file {
+    local file="${1}"
+    local signature_file_out="${2:-${file}.sig}"
+
+    echo "INFO: Signing file ${file} to ${signature_file_out}" 1>&2
+    gpg --output "${signature_file_out}" --detach-sig "${file}"
 }
 
 function main {
@@ -145,11 +156,15 @@ function main {
     local rhel_version="${1:-9}"
     local doc_files="${base_dir}/doc_files.txt"
     local doc_files_cpio="${base_dir}/doc_files_cpio.txt"
+    local docs_archive
 
     check_tools
 
     rawhide_tag=$(get_rawhide_tag)
     nvr=$(get_nvr "${rawhide_tag}")
+
+    docs_archive="${base_dir}/docs-${nvr}.tar.xz"
+
     mkdir -p "${base_dir}"
 
     echo "INFO: Architecture: ${arch}" 1>&2
@@ -166,7 +181,8 @@ function main {
         extract_files_from_rpm "${rpm}" "${base_dir}/install" "${doc_files_cpio}"
     done
     verify_extracted_files "${base_dir}/install" "${doc_files}"
-    create_archive_of_dir "${base_dir}/install"
+    create_archive_of_dir "${base_dir}/install" "${docs_archive}"
+    sign_file "${docs_archive}" "${docs_archive}.sig"
 }
 
 main

--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -22,7 +22,7 @@ function get_rawhide_tag {
 # given tag (e.g. f45). If no tag is provided, it will be determined
 # automatically from whatever tag is assigned to rawhide atm.
 function get_nvr {
-    local tag=${1:-$(get_rawhide_tag)}
+    local tag="${1:-$(get_rawhide_tag)}"
     local nvr
 
     nvr=$(koji latest-build --quiet "${tag}" llvm | cut -d ' ' -f1)
@@ -32,9 +32,9 @@ function get_nvr {
 
 # Downloads the RPMs for a given NVR and architecture into a target directory.
 function download_rpms {
-    local nvr=${1:-$(get_nvr)}
-    local arch=${2:-x86_64}
-    local target_dir=${3:-./$PWD/${arch}}
+    local nvr="${1:-$(get_nvr)}"
+    local arch="${2:-x86_64}"
+    local target_dir="${3:-./$PWD/${arch}}"
 
     echo "INFO: Downloading RPMS for ${nvr} and arch ${arch} to ${target_dir}" 1>&2
     mkdir -p "${target_dir}"
@@ -46,8 +46,8 @@ function download_rpms {
 # Downloads the SRPM for the given NVR so we can extract the llvm.spec file
 # later.
 function download_srpm {
-    local nvr=${1:-$(get_nvr)}
-    local target_dir=${2:-$PWD}
+    local nvr="${1:-$(get_nvr)}"
+    local target_dir="${2:-$PWD}"
     local srpm="${nvr}.src.rpm"
 
     echo "INFO: Downloading ${srpm} to ${target_dir}" 1>&2
@@ -59,8 +59,8 @@ function download_srpm {
 
 # Extracts a given SRPM file to a given target directory.
 function extract_srpm {
-    local srpm=${1:-$(get_nvr).src.rpm}
-    local target_dir=${2:-${PWD}/srpm}
+    local srpm="${1:-$(get_nvr).src.rpm}"
+    local target_dir="${2:-${PWD}/srpm}"
 
     echo "INFO: Extracting SRPM ${srpm} to ${target_dir}" 1>&2
     mkdir -p "${target_dir}"
@@ -72,10 +72,10 @@ function extract_srpm {
 # Writes all files belonging to man page documentation from the given spec file
 # for a given RHEL version to the given destination file list.
 function parse_spec_file_for_doc_files {
-    local spec_file=${1:-${PWD}/srpm/llvm.spec}
-    local rhel_version=${2:-UNDEFINED_RHEL_VERSION}
+    local spec_file="${1:-${PWD}/srpm/llvm.spec}"
+    local rhel_version="${2:-UNDEFINED_RHEL_VERSION}"
     local spec_dir
-    local dest_file_list=${3}
+    local dest_file_list="${3}"
 
     echo "INFO: Parsing spec file ${spec_file} for doc files" 1>&2
     spec_dir=$(dirname "${spec_file}")
@@ -91,9 +91,9 @@ function parse_spec_file_for_doc_files {
 # Extracts all files from the given rpm that are in the files list to the given
 # target directory.
 function extract_files_from_rpm {
-    local rpm=${1}
-    local target_dir=${2}
-    local files_list=${3:-doc-files.txt}
+    local rpm="${1}"
+    local target_dir="${2}"
+    local files_list="${3:-doc-files.txt}"
 
     echo "INFO: Extracting files from ${rpm} in ${target_dir}" 1>&2
     mkdir -p "${target_dir}"
@@ -109,7 +109,7 @@ function main {
     local nvr
     local arch=x86_64
     local base_dir="${PWD}/package-rhel-docs"
-    local rhel_version=${1:-9}
+    local rhel_version="${1:-9}"
     local doc_files="${base_dir}/doc_files.txt"
     local doc_files_cpio="${base_dir}/doc_files_cpio.txt"
 

--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -70,7 +70,8 @@ function extract_srpm {
 }
 
 # Writes all files belonging to man page documentation from the given spec file
-# for a given RHEL version to the given destination file list.
+# in alphabetic order for a given RHEL version to the given destination file
+# list.
 function parse_spec_file_for_doc_files {
     local spec_file="${1:-${PWD}/srpm/llvm.spec}"
     local rhel_version="${2:-UNDEFINED_RHEL_VERSION}"
@@ -84,7 +85,7 @@ function parse_spec_file_for_doc_files {
         --undefine=fedora \
         --define="rhel ${rhel_version}" \
         -P llvm.spec 2>/dev/null \
-    | grep -P '^/usr/share/man' > "${dest_file_list}"
+    | grep -P '^/usr/share/man' | sort > "${dest_file_list}"
     popd
 }
 
@@ -102,6 +103,20 @@ function extract_files_from_rpm {
     # shellcheck disable=SC2046
     rpm2cpio "${rpm}" | cpio -idm $(cat "${files_list}" | tr '\n' ' ')
     popd
+}
+
+# Verifies that the extracted files match those expected from the doc files
+# list text file.
+function verify_extracted_files {
+    local extracted_dir="${1}"
+    local extracted_files="${base_dir}/extracted_files.txt"
+    local doc_files="${2:-doc_files.txt}"
+
+    echo "INFO: Verify that files extracted files are complete" 1>&2
+    pushd "${extracted_dir}"
+    find -L . -type f | sort | sed -s 's/^.//' > "${extracted_files}"
+    popd
+    diff -u "${extracted_files}" "${doc_files}"
 }
 
 function main {
@@ -130,6 +145,7 @@ function main {
     for rpm in "${base_dir}"/*.rpm; do
         extract_files_from_rpm "${rpm}" "${base_dir}/install" "${doc_files_cpio}"
     done
+    verify_extracted_files "${base_dir}/install" "${doc_files}"
 }
 
 main

--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -5,7 +5,7 @@ set -e
 # This function ensures that all tools are installed.
 function check_tools {
     echo "INFO: Checking that all required tools are installed" 1>&2
-    which cpio koji bsdtar rpmspec rpm2cpio grep sed find tar gpg centpkg
+    which cpio koji bsdtar rpmspec rpm2cpio grep sed find tar centpkg
 }
 
 # Prints whatever tag is currently assigned to rawhide in koji (e.g. f45).
@@ -138,16 +138,6 @@ function create_archive_of_dir {
     popd
 }
 
-# Creates a detached GPG signature from the given "<file>" and stores it under
-# "<file>.sig".
-function sign_file {
-    local file="${1}"
-    local signature_file_out="${2:-${file}.sig}"
-
-    echo "INFO: Signing file ${file} to ${signature_file_out}" 1>&2
-    gpg --output "${signature_file_out}" --detach-sig "${file}"
-}
-
 function main {
     local rawhide_tag
     local nvr
@@ -182,7 +172,6 @@ function main {
     done
     verify_extracted_files "${base_dir}/install" "${doc_files}"
     create_archive_of_dir "${base_dir}/install" "${docs_archive}"
-    sign_file "${docs_archive}" "${docs_archive}.sig"
 }
 
 main

--- a/scripts/package-docs-for-rhel.sh
+++ b/scripts/package-docs-for-rhel.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# This function ensures that all tools are installed.
+function check_tools {
+    echo "INFO: Checking that all required tools are installed" 1>&2
+    which cpio koji bsdtar rpmspec rpm2cpio grep sed find tar
+}
+
 # Prints whatever tag is currently assigned to rawhide in koji (e.g. f45).
 function get_rawhide_tag {
     local rawhide_tag
@@ -119,6 +125,18 @@ function verify_extracted_files {
     diff -u "${extracted_files}" "${doc_files}"
 }
 
+# Creates a *.tar.xz archive of the given directory. The name of the archive
+# file will be "<basename-of-archive-dir>.tar.xz".
+function create_archive_of_dir {
+    local extracted_dir="${1}"
+    local target_archive=$(basename "${extracted_dir}").tar.xz
+
+    echo "INFO: Creating archive of ${extracted_dir} in ${target_archive}" 1>&2
+    pushd "${extracted_dir}"
+    tar -cJf "${target_archive}" .
+    popd
+}
+
 function main {
     local rawhide_tag
     local nvr
@@ -127,6 +145,8 @@ function main {
     local rhel_version="${1:-9}"
     local doc_files="${base_dir}/doc_files.txt"
     local doc_files_cpio="${base_dir}/doc_files_cpio.txt"
+
+    check_tools
 
     rawhide_tag=$(get_rawhide_tag)
     nvr=$(get_nvr "${rawhide_tag}")
@@ -146,6 +166,7 @@ function main {
         extract_files_from_rpm "${rpm}" "${base_dir}/install" "${doc_files_cpio}"
     done
     verify_extracted_files "${base_dir}/install" "${doc_files}"
+    create_archive_of_dir "${base_dir}/install"
 }
 
 main


### PR DESCRIPTION
Fixes #2094 - Extract the downloaded RPMS (e.g. using cpio) and copy only the man pages
Fixes #2095 - Create a docs tarball of man pages

Additional changes: 
* Add a `check_tools` function that ensures all required tools are found.
* Enquote parameters to avoid unwanted expansion or splitting.