### PR TITLE
Avoid fetching details when watching for a testing-farm result

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -149,7 +149,7 @@ six==1.16.0
     # via
     #   koji
     #   python-dateutil
-tft-cli==0.0.32
+tft-cli==0.0.37
     # via -r requirements.txt.in
 typer==0.23.1
     # via tft-cli

--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -8,7 +8,7 @@ typing_extensions>=4.12.2
 pandas
 plotly==6.7.0
 copr-cli
-tft-cli==0.0.32
+tft-cli==0.0.37
 regex==2026.5.9
 munch==4.0.0
 copr==2.6

--- a/snapshot_manager/testing_farm/request.py
+++ b/snapshot_manager/testing_farm/request.py
@@ -145,7 +145,7 @@ class Request:
         tfutil.adjust_token_env(self.chroot)
 
         request_id = tfutil.sanitize_request_id(request_id=self.request_id)
-        cmd = f"testing-farm watch --no-wait --id {request_id}"
+        cmd = f"testing-farm watch --no-wait --skip-summary --id {request_id}"
         # We ignore the exit code because in case of a test error, 1 is the exit code
         try:
             logging.info(f"Watching for testing-farm request: {cmd}")


### PR DESCRIPTION
The `--skip-summary` parameter was introduced in
https://gitlab.com/testing-farm/cli/-/commit/b8e235359cff06f877dd2656deaddcee6b1125ad which is why we had to update to a newer testing-farm version.

This should unblock `testing-farm watch` calls that previously ran into timeouts like so:

```
[02/Jul/2026 08:21:05] INFO [tfutil.py:67 adjust_token_env] Adjusting TESTING_FARM_API_TOKEN for ranch: redhat
[02/Jul/2026 08:21:05] INFO [request.py:151 watch] Watching for testing-farm request: testing-farm watch --no-wait --id afa80813-2a8c-403f-b533-27fde5363473
[02/Jul/2026 08:21:45] WARNING [request.py:159 watch] failed to watch for testing-farm result failed to watch 'testing-farm request': testing-farm watch --no-wait --id afa80813-2a8c-403f-b533-27fde5363473

stdout: 🔎 api https://api.dev.testing-farm.io/v0.1/requests/afa80813-2a8c-403f-b533-27fde5363473

stderr:

Command timed out after 40 seconds.
```