### PR TITLE
Adjust check-snapshots scheduling

### DIFF
--- a/.github/workflows/check-snapshots.yml
+++ b/.github/workflows/check-snapshots.yml
@@ -2,9 +2,9 @@ name: "Check snapshots of the last days"
 
 on:
   schedule:
-    # At every 60th minute.
+    # Once every hour.
     # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
-    - cron: "*/60 * * * *"
+    - cron: "17 * * * *"
 
   # This is used when a /retest command asks for a re-check.
   workflow_dispatch:


### PR DESCRIPTION
This used a weird `*/60` syntax, which I *guess* is probably equivalent to just `0`? Scheduling at `0` is not recommended because it has particularly high load. Pick a random other minute value instead.