### PR TITLE
Use another token for running the retest script

### DIFF
--- a/.github/workflows/retest-chroots-on-testing-farm.yml
+++ b/.github/workflows/retest-chroots-on-testing-farm.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run retest script
         shell: bash -e {0}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ORG_PAT_RUN_RETEST_SCRIPT }}
           chroots: ${{ env.chroots }}
         run: |
           python3 snapshot_manager/main.py \


### PR DESCRIPTION
[`GH_ORG_PAT_RUN_RETEST_SCRIPT`](https://github.com/fedora-llvm-team/llvm-snapshots/settings/secrets/actions/GH_ORG_PAT_RUN_RETEST_SCRIPT) is a new token from here https://github.com/organizations/fedora-llvm-team/settings/personal-access-tokens/1841201. It features the "Read and Write access to actions" that @tuliom mentioned in [this comment](https://github.com/fedora-llvm-team/llvm-snapshots/issues/1730#issuecomment-5004715245).